### PR TITLE
Linked Parameter Incorrectly Assigned

### DIFF
--- a/Code/XTMF.Gui/UserControls/LinkedParameterDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/LinkedParameterDisplay.xaml.cs
@@ -87,11 +87,10 @@ namespace XTMF.Gui.UserControls
         /// </summary>
         public void InitNewDisplay()
         {
-
+            _currentlySelected = null;
+            SelectedLinkParameter = null;
             LinkedParameterFilterBox.RetriveFocus();
-
             FocusManager.SetFocusedElement(this,LinkedParameterFilterBox);
-
         }
 
         /// <summary>

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -716,7 +716,7 @@ namespace XTMF.Gui.UserControls
                     MessageBox.Show(GetWindow(), error, "Failed to remove from Linked Parameter", MessageBoxButton.OK,
                         MessageBoxImage.Error);
                 }
-
+                UpdateParameters();
                 UpdateQuickParameterEquivalent(currentParameter);
             }
         }


### PR DESCRIPTION
Cancelling the linked parameters dialog no longer assigns the given parameter after a parameter had previously been selected.
Module Parameters are now refreshed after removing a linked parameter so the GUI is updated.