### PR TITLE
Expanded Root Module on Load

### DIFF
--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -894,6 +894,7 @@ namespace XTMF.Gui.UserControls
             {
                 (DisplayRoot = new ModelSystemStructureDisplayModel(root, null, 0))
             };
+            DisplayRoot.IsExpanded = true;
             return s;
         }
 


### PR DESCRIPTION
When a  model system is loaded the root module is now expanded by default.