### PR TITLE
Write Model Run Complete to Console

### DIFF
--- a/Code/XTMF/Run/XTMFRunRemoteClient.cs
+++ b/Code/XTMF/Run/XTMFRunRemoteClient.cs
@@ -287,6 +287,7 @@ namespace XTMF.Run
                     ModelSystem.SaveQuickParameters(Path.Combine(RunDirectory, "QuickParameters.xml"), _Root);
                     ModelSystemStructureModelRoot = new ModelSystemStructureModel(null, _Root);
                     MST.Start();
+                    Console.WriteLine("Model run complete!");
                     InvokeRunCompleted();
                 }
                 catch (ThreadAbortException)


### PR DESCRIPTION
This will let people know that the model run completed by both writing to the GUI (if run from there) or when reviewing the console output log.