### PR TITLE
LinkedParameter value is set when loading first parameter.

### DIFF
--- a/Code/XTMF/LinkedParameter.cs
+++ b/Code/XTMF/LinkedParameter.cs
@@ -67,6 +67,12 @@ namespace XTMF
                 error = "The parameter '" + parameter.Name + "' already exists within the linked parameter '" + Name + "'.";
                 return false;
             }
+            // If the linked parameter does not already have a value and this is the only thing added, use the parameters value
+            // for the linked parameter.
+            if (String.IsNullOrWhiteSpace(Value) && Parameters.Count == 0)
+            {
+                Value = parameter.Value?.ToString() ?? String.Empty;
+            }
             var value = ArbitraryParameterParser.ArbitraryParameterParse( parameter.Type, Value, ref error );
             if ( value == null )
             {


### PR DESCRIPTION
This will set the linked parameter with no contained parameters to take on the value from that parameter if the LP value is empty.