### PR TITLE
Select StringDialog starting text.

### DIFF
--- a/Code/XTMF.Gui/UserControls/StringRequestDialog.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/StringRequestDialog.xaml.cs
@@ -68,6 +68,7 @@ namespace XTMF.Gui.UserControls
         private void OpenedEventHandler(object sender, DialogOpenedEventArgs eventargs)
         {
             this._dialogSession = eventargs.Session;
+            StringInputTextBox.Select(0, StringInputTextBox.Text.Length);
         }
 
         /// <summary>


### PR DESCRIPTION
This patch will automatically select the starting text when opening the string dialog.  This makes it easier to rename and or copy the text.