### PR TITLE
Fix Copy Stack Trace.

### DIFF
--- a/Code/XTMF.Gui/UserControls/SchedulerWindow.xaml
+++ b/Code/XTMF.Gui/UserControls/SchedulerWindow.xaml
@@ -25,7 +25,7 @@
                              Text="{Binding StackTrace}" Style="{DynamicResource MaterialDesignSubheadingTextBox}"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <TextBlock HorizontalAlignment="Center" Margin="0 5 5 5">
-                            <Hyperlink Style="{DynamicResource MaterialDesignBody1HyperlinkCustom}" Tag="{Binding .,ElementName=SchedulerWindow}"
+                            <Hyperlink Style="{DynamicResource MaterialDesignBody1HyperlinkCustom}" Tag="{Binding .}"
                                        Click="Hyperlink_OnClick">
                                 <materialDesign:PackIcon Kind="ContentCopy" />
                                 Copy to Clipboard
@@ -33,7 +33,7 @@
                         </TextBlock>
                         <TextBlock HorizontalAlignment="Center" Margin="5 5 0 5">
                             <Hyperlink Name="CloseDialogHyperLink"
-                                       Style="{DynamicResource MaterialDesignBody1HyperlinkCustom}" Tag="{Binding .}"
+                                       Style="{DynamicResource MaterialDesignBody1HyperlinkCustom}"
                                        Click="CloseDialogHyperLink_OnClick">
                                 <materialDesign:PackIcon Kind="Close" />
                                 Close

--- a/Code/XTMF.Gui/UserControls/SchedulerWindow.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/SchedulerWindow.xaml.cs
@@ -88,9 +88,12 @@ namespace XTMF.Gui.UserControls
         private void Hyperlink_OnClick(object sender, RoutedEventArgs e)
         {
             var error = (sender as FrameworkContentElement)?.Tag as ModelSystemErrorDisplayModel;
-            Clipboard.SetText(error.StackTrace == "Unavailable"
-                ? error.Description
-                : error.Description + "\r\n" + error.StackTrace);
+            if (error != null)
+            {
+                Clipboard.SetText(error.StackTrace == "Unavailable"
+                    ? error.Description
+                    : error.Description + "\r\n" + error.StackTrace);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This patch fixes the copy stack trace button when viewing  the stack trace of a failed run.