### PR TITLE
Fix dwelling type and Income Class

### DIFF
--- a/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
+++ b/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
@@ -400,7 +400,11 @@ namespace TMG.Tasha.MicrosimLoader
             {
                 vehicles[i] = Vehicle.MakeVehicle(Root.AutoType);
             }
-            return new Household(household.HouseholdID, new ITashaPerson[numberOfPersons], vehicles, household.Weight, zoneSystem.GetFlatData()[homeZoneIndex]);
+            return new Household(household.HouseholdID, new ITashaPerson[numberOfPersons], vehicles, household.Weight, zoneSystem.GetFlatData()[homeZoneIndex])
+            {
+                DwellingType = (DwellingType)(household.DwellingType),
+                IncomeClass = household.IncomeClass
+            };
         }
 
         private static bool IsHouseholdActivityPurpose(string purpose)


### PR DESCRIPTION
Copies over the dwelling type and income class from the microsim household object to the TASHA household object.