### PR TITLE
Fix Start Time Adjustments

### DIFF
--- a/Tasha/Scheduler/Distribution2.cs
+++ b/Tasha/Scheduler/Distribution2.cs
@@ -181,7 +181,7 @@ namespace Tasha.Scheduler
                     && adjustments[i].HomePlanningDistricts.Contains(householdPD)
                     && adjustments[i].WorkPlanningDistrict.Contains(workPD))
                 {
-                    adjustments[pos++] = adjustments[i];
+                    adjustmentsToApply[pos++] = i;
                 }
             }
             return pos;


### PR DESCRIPTION
Fixes the start time adjustment logic for TASHA's scheduler.  The previous implementation would only work with a single adjustment.  It looks like the implementation change from returning back references to the adjustment modules had an error in the inner loop.