### PR TITLE
Tasha performance

### DIFF
--- a/Code/XTMF.Run/Properties/launchSettings.json
+++ b/Code/XTMF.Run/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "XTMF.Run": {
       "commandName": "Project",
-      "commandLineArgs": "\"GTAModel V4.2.0\" \"GTAModel V4.2.0\" test-console",
+      "commandLineArgs": "\"GTAModelV4.2\" \"NoEMME\" test-console",
       "hotReloadEnabled": false
     }
   }

--- a/Tasha/Scheduler/SchedulerTripChain.cs
+++ b/Tasha/Scheduler/SchedulerTripChain.cs
@@ -30,7 +30,7 @@ namespace Tasha.Scheduler
         private SchedulerTripChain(ITashaPerson person)
         {
             Person = person;
-            Trips = new List<ITrip>( 3 );
+            Trips = new List<ITrip>(3);
         }
 
         /// <summary>
@@ -65,15 +65,15 @@ namespace Tasha.Scheduler
         {
             get
             {
-                if ( !JointTrip ) return null;
+                if (!JointTrip) return null;
 
                 List<ITripChain> linkedTripChains = new List<ITripChain>();
-                foreach ( var p in Person.Household.Persons )
+                foreach (var p in Person.Household.Persons)
                 {
-                    foreach ( var tripChain in p.TripChains )
+                    foreach (var tripChain in p.TripChains)
                     {
-                        if ( tripChain.JointTripID == JointTripID )
-                            linkedTripChains.Add( tripChain );
+                        if (tripChain.JointTripID == JointTripID)
+                            linkedTripChains.Add(tripChain);
                     }
                 }
                 return linkedTripChains;
@@ -118,13 +118,13 @@ namespace Tasha.Scheduler
             {
                 List<IVehicleType> v = new List<IVehicleType>();
 
-                foreach ( var trip in Trips )
+                foreach (var trip in Trips)
                 {
-                    if ( trip.Mode != null && trip.Mode.RequiresVehicle != null )
+                    if (trip.Mode != null && trip.Mode.RequiresVehicle != null)
                     {
-                        if ( !v.Contains( trip.Mode.RequiresVehicle ) )
+                        if (!v.Contains(trip.Mode.RequiresVehicle))
                         {
-                            v.Add( trip.Mode.RequiresVehicle );
+                            v.Add(trip.Mode.RequiresVehicle);
                         }
                     }
                 }
@@ -148,9 +148,9 @@ namespace Tasha.Scheduler
         {
             get
             {
-                foreach ( var t in Trips )
+                foreach (var t in Trips)
                 {
-                    if ( !t.Mode.NonPersonalVehicle )
+                    if (!t.Mode.NonPersonalVehicle)
                     {
                         return true;
                     }
@@ -176,7 +176,7 @@ namespace Tasha.Scheduler
         {
             ITripChain chain = (ITripChain)MemberwiseClone();
             chain.Trips = new List<ITrip>();
-            chain.Trips.AddRange( Trips );
+            chain.Trips.AddRange(Trips);
             return chain;
         }
 
@@ -192,14 +192,14 @@ namespace Tasha.Scheduler
             List<ITrip> trips = new List<ITrip>();
 
             //cloning trips as well and setting their trip chain to cloned chained
-            foreach ( var trip in Trips )
+            foreach (var trip in Trips)
             {
                 ITrip t = trip.Clone();
                 t.TripChain = chain;
-                trips.Add( t );
+                trips.Add(t);
             }
 
-            chain.Trips.AddRange( trips );
+            chain.Trips.AddRange(trips);
 
             return chain;
         }
@@ -207,7 +207,7 @@ namespace Tasha.Scheduler
         public void Recycle()
         {
             Release();
-            foreach ( var t in Trips )
+            foreach (var t in Trips)
             {
                 t.Release();
             }
@@ -215,15 +215,12 @@ namespace Tasha.Scheduler
             JointTripID = 0;
             JointTripRep = false;
             GetRepTripChain = null;
-            if ( JointTripChains != null )
+            if (JointTripChains != null)
             {
                 JointTripChains.Clear();
             }
             Person = null;
-            if(Chains.Count < 100)
-            {
-                Chains.Enqueue(this);
-            }
+            Chains.Enqueue(this);
         }
 
         internal static SchedulerTripChain GetTripChain(ITashaPerson person)

--- a/Tasha/TashaRuntime.cs
+++ b/Tasha/TashaRuntime.cs
@@ -273,13 +273,6 @@ namespace Tasha
                     CurrentHousehold = 0;
                     CurrentIteration = i;
                     CompletedIterationPercentage = i * IterationPercentage;
-                    if (LoadAllHouseholds)
-                    {
-                        if (!SkipLoadingHouseholds)
-                        {
-                            HouseholdLoader.LoadData();
-                        }
-                    }
                     RunIteration(i);
                 }
             }
@@ -577,6 +570,13 @@ namespace Tasha
             RunPreIterationModules(i);
             RunStartIteration(i);
             RunIterationSensitiveStart(i);
+            if (LoadAllHouseholds)
+            {
+                if (!SkipLoadingHouseholds)
+                {
+                    HouseholdLoader.LoadData();
+                }
+            }
             _Progress = () => (Math.Min(((float)CurrentHousehold / NumberOfHouseholds), 1.0f) / TotalIterations + CompletedIterationPercentage);
             if (!SkipLoadingHouseholds)
             {

--- a/Tasha/XTMFScheduler/LocationChoice/V4LocationChoice.cs
+++ b/Tasha/XTMFScheduler/LocationChoice/V4LocationChoice.cs
@@ -138,11 +138,7 @@ namespace Tasha.XTMFScheduler.LocationChoice
                     result = WorkBasedBusinessModel.GetLocation(previousZone, ep, nextZone, startTime, availableTime, calculationSpace, random);
                     break;
             }
-            // if it isn't something that we understand just accept its previous zone
-            if (CalculationPool.Count <= Cores)
-            {
-                CalculationPool.Enqueue(calculationSpace);
-            }
+            CalculationPool.Enqueue(calculationSpace);
             return result;
         }
 
@@ -458,7 +454,7 @@ namespace Tasha.XTMFScheduler.LocationChoice
                     + TransitWalk * walk
                     + TransitWait * wait
                     + TransitBoarding * boarding
-                    + Cost * cost)/scaleFactor);
+                    + Cost * cost) / scaleFactor);
             }
 
             protected float GetTravelLogsum(INetworkData autoNetwork, ITripComponentData transitNetwork, float[][] distances, int i, int j, Time time,
@@ -559,8 +555,8 @@ namespace Tasha.XTMFScheduler.LocationChoice
                 });
                 Parallel.For(0, zones2, index =>
                 {
-                    autoSpace[index] = (float)Math.Pow(Math.Exp(autoSpace[index]/ timePeriodParameters.TravelLogsumDenominator) + Math.Exp(transitSpace[index]/ timePeriodParameters.TravelLogsumDenominator)
-                        + Math.Exp(activeSpace[index]/ timePeriodParameters.TravelLogsumDenominator), timePeriodParameters.TravelLogsumScale);
+                    autoSpace[index] = (float)Math.Pow(Math.Exp(autoSpace[index] / timePeriodParameters.TravelLogsumDenominator) + Math.Exp(transitSpace[index] / timePeriodParameters.TravelLogsumDenominator)
+                        + Math.Exp(activeSpace[index] / timePeriodParameters.TravelLogsumDenominator), timePeriodParameters.TravelLogsumScale);
                 });
                 return autoSpace;
             }
@@ -685,7 +681,7 @@ namespace Tasha.XTMFScheduler.LocationChoice
                                 var totalEmp = ((pf[i] + pp[i]) + (gf[i] + gp[i])) + ((sf[i] + sp[i]) + (mf[i] + mp[i]));
                                 var logOfEmp = Math.Log(totalEmp + 1);
                                 empTerm = Math.Exp(
-                                    (ProfessionalFullTime * pf[i]  +
+                                    (ProfessionalFullTime * pf[i] +
                                     ProfessionalPartTime * pp[i] +
                                     GeneralFullTime * gf[i] +
                                     GeneralPartTime * gp[i] +

--- a/TorontoHouseholds/Household.cs
+++ b/TorontoHouseholds/Household.cs
@@ -80,7 +80,7 @@ namespace Tasha.Common
         {
             get
             {
-                if (_NumberOfAdults == -1 )
+                if (_NumberOfAdults == -1)
                 {
                     _NumberOfAdults = 0;
                     foreach (ITashaPerson p in Persons)
@@ -174,10 +174,7 @@ namespace Tasha.Common
                 vehicles[i].Recycle();
             }
             _NumberOfAdults = -1;
-            if(Households.Count < 100)
-            {
-                Households.Add(this);
-            }
+            Households.Add(this);
         }
 
         internal static void ReleaseHouseholdPool()
@@ -205,7 +202,7 @@ namespace Tasha.Common
                 {
                     foreach (var tc in person.TripChains)
                     {
-                        if (tc.JointTripChains == null )
+                        if (tc.JointTripChains == null)
                             continue;
 
                         foreach (var jtc in tc.JointTripChains)
@@ -249,9 +246,9 @@ namespace Tasha.Common
         {
             Household newH = (Household)MemberwiseClone();
             newH.Variables = new SortedList<string, object>();
-            newH.Attach("Maintainer", this["Maintainer"] );
+            newH.Attach("Maintainer", this["Maintainer"]);
             newH.Persons = new ITashaPerson[Persons.Length];
-            for ( int i = 0; i < Persons.Length; i++)
+            for (int i = 0; i < Persons.Length; i++)
             {
                 Person newPerson = (Person)Persons[i].Clone();
                 newPerson.Household = newH;

--- a/TorontoHouseholds/HouseholdLoader.cs
+++ b/TorontoHouseholds/HouseholdLoader.cs
@@ -585,6 +585,7 @@ namespace TMG.Tasha
                 }
                 NeedsReset = true;
                 AllDataLoaded = Reader.EndOfFile;
+                AutoOwnershipModel?.Load();
                 while (LoadNextHousehold(list) && !AllDataLoaded)
                 {
                 }

--- a/TorontoHouseholds/Person.cs
+++ b/TorontoHouseholds/Person.cs
@@ -215,10 +215,7 @@ namespace Tasha.Common
             AuxTripChains.Clear();
             EmploymentZone = null;
             SchoolZone = null;
-            if (People.Count < 100)
-            {
-                People.Add(this);
-            }
+            People.Add(this);
         }
 
         public List<ITripChain> AuxTripChains

--- a/TorontoHouseholds/Vehicle.cs
+++ b/TorontoHouseholds/Vehicle.cs
@@ -66,17 +66,14 @@ namespace Tasha.Common
                 v.VehicleType = type;
                 return v;
             }
-            return new Vehicle( type );
+            return new Vehicle(type);
         }
 
         public void Recycle()
         {
             VehicleType = null;
             Release();
-            if(Vehicles.Count < 100)
-            {
-                Vehicles.Add(this);
-            }
+            Vehicles.Add(this);
         }
     }
 }


### PR DESCRIPTION
This PR removes the limits originally placed when recycling TASHA objects.  On our many core system this lead to a 50% reduction in runtime for V4.2 when running without any extra output modules.