### PR TITLE
Add modules for converting matrices and vectors between zone systems.

### DIFF
--- a/Code/TMG.Frameworks/Data/Loading/LoadVectorInZoneSystem.cs
+++ b/Code/TMG.Frameworks/Data/Loading/LoadVectorInZoneSystem.cs
@@ -1,0 +1,111 @@
+﻿/*
+    Copyright 2023 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Datastructure;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using TMG.Input;
+using XTMF;
+
+namespace TMG.Frameworks.Data.Loading;
+
+[ModuleInformation(Description = "Load a vector with the given zone system.")]
+public sealed class LoadVectorInZoneSystem : IDataSource<SparseArray<float>>
+{
+    private volatile bool _loaded = false;
+    private SparseArray<float> _data;
+
+    [SubModelInformation(Required = true, Description = "The zone system that the resulting vector should match.")]
+    public IDataSource<IZoneSystem> ZoneSystem;
+
+    [SubModelInformation(Required = true, Description = "The data reason to load in the data from, only the origin will be considered.")]
+    public IReadODData<float> DataSource;
+
+    [RunParameter("Continue After Invalid Zone", false, "Should the model system continue after an invalid zone number has been read in?")]
+    public bool ContinueAfterInvalidZone;
+
+    public SparseArray<float> GiveData()
+    {
+        return _data;
+    }
+
+    public bool Loaded => _loaded;
+
+    public void LoadData()
+    {
+        var zoneSystem = Load(ZoneSystem);
+        var data = zoneSystem.CreateSimilarArray<float>();
+        if (ContinueAfterInvalidZone)
+        {
+            foreach (var entry in DataSource.Read())
+            {
+                _ = data.TryStore(entry.O, entry.Data);
+            }
+        }
+        else
+        {
+            foreach (var entry in DataSource.Read())
+            {
+                if (!data.TryStore(entry.O, entry.Data))
+                {
+                    ThrowInvalidIndex(entry.O, entry.Data);
+                }
+            }
+        }
+        _data = data;
+        _loaded = true;
+    }
+
+    [DoesNotReturn]
+    private void ThrowInvalidIndex(int origin, float data)
+    {
+        throw new XTMFRuntimeException(this, $"We ran into an issue where a zone {origin} was trying to be assigned to with the value of {data} but that origin does not exist!");
+    }
+
+    private static SparseArray<IZone> Load(IDataSource<IZoneSystem> zoneSystem)
+    {
+        if (zoneSystem.Loaded)
+        {
+            return zoneSystem.GiveData().ZoneArray;
+        }
+        else
+        {
+            zoneSystem.LoadData();
+            var ret = zoneSystem.GiveData().ZoneArray;
+            zoneSystem.UnloadData();
+            return ret;
+        }
+    }
+
+    public void UnloadData()
+    {
+        _loaded = false;
+        _data = null;
+    }
+
+    public string Name { get; set; }
+
+    public float Progress => 0f;
+
+    public Tuple<byte, byte, byte> ProgressColour => new(50,150,50);
+
+    public bool RuntimeValidation(ref string error)
+    {
+        return true;
+    }
+}

--- a/Code/TMG.Frameworks/Data/Processing/ConvertMatrixBetweenZoneSystems.cs
+++ b/Code/TMG.Frameworks/Data/Processing/ConvertMatrixBetweenZoneSystems.cs
@@ -1,0 +1,278 @@
+﻿/*
+    Copyright 2023 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Datastructure;
+using System;
+using System.Numerics;
+using TMG.Functions;
+using TMG.Input;
+using System.Linq;
+using XTMF;
+
+namespace TMG.Frameworks.Data.Processing;
+
+[ModuleInformation(Description = "Converts a matrix between two zone systems using a mapping file that gives the factor to apply between zones.")]
+public sealed class ConvertMatrixBetweenZoneSystems : IDataSource<SparseTwinIndex<float>>
+{
+    [RootModule]
+    public ITravelDemandModel Root;
+
+    [SubModelInformation(Required = true, Description = "The zone system the OD data was designed for")]
+    public IDataSource<IZoneSystem> OriginalZoneSystem;
+
+    [SubModelInformation(Required = false, Description = "The zone system the OD data will be converted for, leave blank to use the model system's zone system.")]
+    public IDataSource<IZoneSystem> ConvertToZoneSystem;
+
+    [SubModelInformation(Required = true, Description = "The data to convert")]
+    public IDataSource<SparseTwinIndex<float>> Original;
+
+    [SubModelInformation(Required = true, Description = "The location to read the CSV mapping file from, OriginalZone,ConvertedZone,Fraction")]
+    public FileLocation MapFile;
+
+    public string Name { get; set; }
+
+    public float Progress { get; set; }
+
+    public Tuple<byte, byte, byte> ProgressColour => new(50, 150, 50);
+
+    public enum Aggregations
+    {
+        Sum,
+        Average
+    }
+
+    [RunParameter("Aggregation", "Sum", typeof(Aggregations), "The aggregation to apply")]
+    public Aggregations Aggregation;
+
+    public bool Loaded { get; set; }
+
+    public bool RuntimeValidation(ref string error)
+    {
+        return true;
+    }
+
+    private SparseTwinIndex<float> _data;
+
+    public SparseTwinIndex<float> GiveData() => _data;
+
+    public void LoadData()
+    {
+        var originalZones = LoadZoneSystem(OriginalZoneSystem);
+        var convertToZones = LoadZoneSystem(ConvertToZoneSystem ?? Root.ZoneSystem);
+        var ret = SparseTwinIndex<float>.CreateSquareTwinIndex(convertToZones, convertToZones);
+        var original = GetData(Original);
+        var flat = ret.GetFlatData();
+        var map = ColumnNormalize(BuildMapping(originalZones, convertToZones), originalZones.Length);
+        switch (Aggregation)
+        {
+            case Aggregations.Sum:
+                ApplySum(map, flat, original);
+                break;
+            case Aggregations.Average:
+                ApplyAverage(map, flat, original);
+                break;
+        }
+        _data = ret;
+        Loaded = true;
+    }
+
+    private static float[] ColumnNormalize(float[] map, int columns)
+    {
+        var rows = map.Length / columns;
+        int column = 0;
+        for (; column < columns - Vector<float>.Count; column += Vector<float>.Count)
+        {
+            var vTotal = Vector<float>.Zero;
+            for (int row = 0; row < rows; row++)
+            {
+                vTotal += new Vector<float>(map, row * columns + column);
+            }
+            vTotal = VectorHelper.SelectIfFinite(Vector<float>.One / vTotal, Vector<float>.Zero);
+            for (int row = 0; row < rows; row++)
+            {
+                int index = row * columns + column;
+                (new Vector<float>(map, index) * vTotal).CopyTo(map, index);
+            }
+        }
+        for (; column < columns; column++)
+        {
+            var total = 0.0f;
+            for (int row = 0; row < rows; row++)
+            {
+                total += map[row * columns + column];
+            }
+            total = 1.0f / total;
+            if (float.IsNaN(total) || float.IsInfinity(total))
+            {
+                total = 0.0f;
+            }
+            for (int row = 0; row < rows; row++)
+            {
+                map[row * columns + column] *= total;
+            }
+        }
+        return map;
+    }
+
+    private void ApplySum(float[] map, float[][] flatRet, SparseTwinIndex<float> original)
+    {
+        var flatOrigin = original.GetFlatData();
+        System.Threading.Tasks.Parallel.For(0, flatRet.Length, (int i) =>
+        {
+            for (int j = 0; j < flatRet[i].Length; j++)
+            {
+                flatRet[i][j] = ComputeSum(map, flatOrigin, i, j);
+            }
+        });
+    }
+
+    private void ApplyAverage(float[] map, float[][] flatRet, SparseTwinIndex<float> original)
+    {
+        var flatOrigin = original.GetFlatData();
+        System.Threading.Tasks.Parallel.For(0, flatRet.Length, (int i) =>
+        {
+            for (int j = 0; j < flatRet[i].Length; j++)
+            {
+                flatRet[i][j] = ComputeAverage(map, flatOrigin, i, j);
+            }
+        });
+    }
+
+    private static float ComputeAverage(float[] map, float[][] flatOrigin, int retRow, int retColumn)
+    {
+        var ret = 0.0f;
+        var rowBase = flatOrigin.Length * retRow;
+        var columnBase = flatOrigin.Length * retColumn;
+        Vector<float> vRet = Vector<float>.Zero;
+        Vector<float> vFactorSum = Vector<float>.Zero;
+        float factorSum = 0.0f;
+        for (int i = 0; i < flatOrigin.Length; i++)
+        {
+            var iFactor = map[rowBase + i];
+            var row = flatOrigin[i];
+            if (iFactor > 0)
+            {
+                int j = 0;
+                Vector<float> iFactorV = new Vector<float>(iFactor);
+                for (; j < row.Length - Vector<float>.Count; j += Vector<float>.Count)
+                {
+                    var rowV = new Vector<float>(row, j);
+                    var mapV = new Vector<float>(map, columnBase + j);
+                    var factor = iFactorV * mapV;
+                    vFactorSum += factor;
+                    vRet += rowV * factor;
+                }
+                for (; j < row.Length; j++)
+                {
+                    var factor = iFactor * map[columnBase + j];
+                    factorSum += factor;
+                    ret += row[j] * factor;
+                }
+            }
+        }
+        ret += Vector.Sum(vRet);
+        ret /= (factorSum + Vector.Sum(vFactorSum));
+        return ret;
+    }
+
+    private float ComputeSum(float[] map, float[][] flatOrigin, int retRow, int retColumn)
+    {
+        var ret = 0.0f;
+        var rowBase = flatOrigin.Length * retRow;
+        var columnBase = flatOrigin.Length * retColumn;
+        Vector<float> vRet = Vector<float>.Zero;
+        for (int i = 0; i < flatOrigin.Length; i++)
+        {
+            var iFactor = map[rowBase + i];
+            var row = flatOrigin[i];
+            if (iFactor > 0)
+            {
+                int j = 0;
+                Vector<float> iFactorV = new(iFactor);
+                for (; j < row.Length - Vector<float>.Count; j += Vector<float>.Count)
+                {
+                    var rowV = new Vector<float>(row, j);
+                    var mapV = new Vector<float>(map, columnBase + j);
+                    vRet += rowV * iFactorV * mapV;
+                }
+                for (; j < row.Length; j++)
+                {
+                    ret += row[j] * iFactor * map[columnBase + j];
+                }
+            }
+        }
+        ret += Vector.Dot(vRet, Vector<float>.One);
+        return ret;
+    }
+
+    private SparseTwinIndex<float> GetData(IDataSource<SparseTwinIndex<float>> original)
+    {
+        if (original.Loaded)
+        {
+            return original.GiveData();
+        }
+        else
+        {
+            original.LoadData();
+            var ret = original.GiveData();
+            original.UnloadData();
+            return ret;
+        }
+    }
+
+    private float[] BuildMapping(int[] originalZones, int[] convertToZones)
+    {
+        var map = new float[originalZones.Length * convertToZones.Length];
+        using (var reader = new CsvReader(MapFile))
+        {
+            reader.LoadLine();
+            while (reader.LoadLine(out int columns))
+            {
+                if (columns >= 3)
+                {
+                    reader.Get(out int origin, 0);
+                    reader.Get(out int destination, 1);
+                    reader.Get(out float ratio, 2);
+                    // convert the indexes into flat index look ups
+                    origin = Array.BinarySearch(originalZones, origin);
+                    destination = Array.BinarySearch(convertToZones, destination);
+                    map[destination * originalZones.Length + origin] = ratio;
+                }
+            }
+        }
+        return map;
+    }
+
+    private static int[] LoadZoneSystem(IDataSource<IZoneSystem> zoneSystem)
+    {
+        if (!zoneSystem.Loaded)
+        {
+            zoneSystem.LoadData();
+        }
+        return zoneSystem.GiveData()
+            .ZoneArray.GetFlatData()
+            .Select(z => z.ZoneNumber)
+            .ToArray();
+    }
+
+    public void UnloadData()
+    {
+        _data = null;
+        Loaded = false;
+    }
+}

--- a/Code/TMG.Frameworks/Data/Processing/ConvertVectorBetweenZoneSystems.cs
+++ b/Code/TMG.Frameworks/Data/Processing/ConvertVectorBetweenZoneSystems.cs
@@ -1,0 +1,178 @@
+﻿/*
+    Copyright 2023 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Datastructure;
+using System;
+using System.Numerics;
+using TMG.Functions;
+using TMG.Input;
+using XTMF;
+
+namespace TMG.Frameworks.Data.Processing;
+
+[ModuleInformation(Description = "This module is designed to convert a vector between two" +
+    " zone systems using a mapping file that relates the factor to apply.")]
+public sealed class ConvertVectorBetweenZoneSystems : IDataSource<SparseArray<float>>
+{
+    private volatile bool _loaded;
+
+    private SparseArray<float> _data;
+
+    [RootModule]
+    public ITravelDemandModel Root;
+
+    [SubModelInformation(Required = true, Description = "")]
+    public IDataSource<SparseArray<float>> OriginalVector;
+
+    [SubModelInformation(Required = false, Description = "The zone system the data will be converted for, leave blank to use the model system's zone system.")]
+    public IDataSource<IZoneSystem> ConvertToZoneSystem;
+
+    [SubModelInformation(Required = true, Description = "The location to read the CSV mapping file from, OriginalZone,ConvertedZone,Fraction")]
+    public FileLocation MapFile;
+
+    public SparseArray<float> GiveData()
+    {
+        return _data;
+    }
+
+    public bool Loaded => _loaded;
+
+    public void LoadData()
+    {
+        var original = LoadDataSource(OriginalVector);
+        var destination = LoadDataSource(ConvertToZoneSystem ?? Root.ZoneSystem).ZoneArray;
+        var map = ColumnNormalize(BuildMapping(MapFile, original.ValidIndexArray(), destination.ValidIndexArray()), original.Count);
+        _data = ConvertData(original, destination, map);
+        _loaded = true;
+    }
+
+    private SparseArray<float> ConvertData(SparseArray<float> original, SparseArray<IZone> destination, float[] map)
+    {
+        var ret = destination.CreateSimilarArray<float>();
+        System.Threading.Tasks.Parallel.For(0, destination.Count, (int destinationIndex) =>
+        {
+            var originalVector = original.GetFlatData().AsSpan();
+            var mapVector = map.AsSpan(destinationIndex * originalVector.Length, originalVector.Length);
+            // You might want to look into the false sharing that this store operation is going to cause
+            ret.GetFlatData()[destinationIndex] = VectorHelper.MultiplyAndSumNoStore(originalVector, mapVector);
+        });
+        return ret;
+    }
+
+    private static float[] BuildMapping(FileLocation mapFile, int[] originalZones, int[] convertToZones)
+    {
+        var map = new float[originalZones.Length * convertToZones.Length];
+        using (var reader = new CsvReader(mapFile))
+        {
+            reader.LoadLine();
+            while (reader.LoadLine(out int columns))
+            {
+                if (columns >= 3)
+                {
+                    reader.Get(out int origin, 0);
+                    reader.Get(out int destination, 1);
+                    reader.Get(out float ratio, 2);
+                    // convert the indexes into flat index look ups
+                    origin = Array.BinarySearch(originalZones, origin);
+                    destination = Array.BinarySearch(convertToZones, destination);
+                    map[destination * originalZones.Length + origin] = ratio;
+                }
+            }
+        }
+        return map;
+    }
+
+    private static float[] ColumnNormalize(float[] map, int columns)
+    {
+        var rows = map.Length / columns;
+        int column = 0;
+        for (; column < columns - Vector<float>.Count; column += Vector<float>.Count)
+        {
+            var vTotal = Vector<float>.Zero;
+            for (int row = 0; row < rows; row++)
+            {
+                vTotal += new Vector<float>(map, row * columns + column);
+            }
+            vTotal = VectorHelper.SelectIfFinite(Vector<float>.One / vTotal, Vector<float>.Zero);
+            for (int row = 0; row < rows; row++)
+            {
+                int index = row * columns + column;
+                (new Vector<float>(map, index) * vTotal).CopyTo(map, index);
+            }
+        }
+        for (; column < columns; column++)
+        {
+            var total = 0.0f;
+            for (int row = 0; row < rows; row++)
+            {
+                total += map[row * columns + column];
+            }
+            total = 1.0f / total;
+            if (float.IsNaN(total) || float.IsInfinity(total))
+            {
+                total = 0.0f;
+            }
+            for (int row = 0; row < rows; row++)
+            {
+                map[row * columns + column] *= total;
+            }
+        }
+        return map;
+    }
+
+
+    private static T LoadDataSource<T>(IDataSource<T> dataSource)
+    {
+        if (!dataSource.Loaded)
+        {
+            dataSource.LoadData();
+            var ret = dataSource.GiveData();
+            dataSource.UnloadData();
+            return ret;
+        }
+        else
+        {
+            return dataSource.GiveData();
+        }
+    }
+
+    public void UnloadData()
+    {
+        lock (this)
+        {
+            _data = null;
+            _loaded = false;
+        }
+    }
+
+    public string Name { get; set; }
+
+    public float Progress => 0f;
+
+    public Tuple<byte, byte, byte> ProgressColour => new(50,150,50);
+
+    public bool RuntimeValidation(ref string error)
+    {
+        if(ConvertToZoneSystem is null && Root.ZoneSystem is null)
+        {
+            error = "At least one of ConvertToZoneSystem or the model system's Zone System need to be defined!";
+            return false;
+        }
+        return true;
+    }
+}

--- a/Code/TMG.Functions/VectorHelper.cs
+++ b/Code/TMG.Functions/VectorHelper.cs
@@ -17,6 +17,7 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -46,6 +47,12 @@ namespace TMG.Functions
             where K : struct
         {
             return MemoryMarshal.Cast<T, K>(span);
+        }
+
+        [DoesNotReturn]
+        private static void ThrowVectorsMustBeSameSize()
+        {
+            throw new ArgumentException("Vectors must be the same size!");
         }
 
         /// <summary>

--- a/Datastructure/SparseArray.cs
+++ b/Datastructure/SparseArray.cs
@@ -72,6 +72,39 @@ namespace Datastructure
             }
         }
 
+        /// <summary>
+        /// Read the value if the sparse index exists.
+        /// </summary>
+        /// <param name="sparseIndex">The sparse index to read from.</param>
+        /// <param name="data">The data that was read, default if it does not exist.</param>
+        /// <returns>True if the sparse index exists, false otherwise.</returns>
+        public bool TryRead(int sparseIndex, out T data)
+        {
+            if (GetTransformedIndex(ref sparseIndex))
+            {
+                data = Data[sparseIndex];
+                return true;
+            }
+            data = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Store the value if the sparse index exists.
+        /// </summary>
+        /// <param name="sparseIndex">The sparse index to write to.</param>
+        /// <param name="data">The data to write.</param>
+        /// <returns>True if the sparse index exists, false otherwise.</returns>
+        public bool TryStore(int sparseIndex, T data)
+        {
+            if (GetTransformedIndex(ref sparseIndex))
+            {
+                Data[sparseIndex] = data;
+                return true;
+            }
+            return false;
+        }
+
         public static SparseArray<T> CreateSparseArray(int[] sparseSpace, IList<T> data)
         {
             var length = sparseSpace.Length;


### PR DESCRIPTION
Sometimes we need to convert data between different renditions of zone systems.  In this PR add serveral new modules.

1. LoadVectorInZoneSystem - Allows us to read in data from a different zone system.
2. ConvertMatrixBetweenZoneSystems - Allows us to convert a matrix using a mapping file between zone systems.
3. ConvertVectorBetweenZoneSystems - Allows us to convert a vector using a mapping file between zone systems.