### PR TITLE
Revert to MaterialDesign 0.2.8 to fix hint text

### DIFF
--- a/Code/XTMF.Gui/XTMF.Gui.csproj
+++ b/Code/XTMF.Gui/XTMF.Gui.csproj
@@ -121,7 +121,7 @@
 			<Version>2.4.9</Version>
 		</PackageReference>
 		<PackageReference Include="MaterialDesignThemes.MahApps">
-			<Version>0.3.0</Version>
+			<Version>0.2.8</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />


### PR DESCRIPTION
The update to use verison 0.3.0 seems to be causing the issues where if a parameter has more than one line of text then the hint text becomes obscured.  Reverting the one library seems to fix this issue.