### PR TITLE
Fix AddTransferTimeAdjustmentsFromCSV

### DIFF
--- a/Code/TMG.Emme/Tools/NetworkEditing/TransitFareHypernetworks/AddTransferTimeAdjustments.cs
+++ b/Code/TMG.Emme/Tools/NetworkEditing/TransitFareHypernetworks/AddTransferTimeAdjustments.cs
@@ -23,7 +23,9 @@ using XTMF;
 using System.IO;
 using System.Text.Json;
 using Datastructure;
-
+using TMG.Functions;
+using System.Text.Unicode;
+using System.Text;
 
 namespace TMG.Emme.Tools.NetworkEditing.TransitFareHypernetworks
 {
@@ -109,7 +111,7 @@ namespace TMG.Emme.Tools.NetworkEditing.TransitFareHypernetworks
                     writer.WriteString("transfer_modes", TransferModes);
                     writer.WriteEndObject();
                 }
-                return stream.ToString();
+                return Encoding.UTF8.GetString(stream.ToArray());
             }
         }
 


### PR DESCRIPTION
There was a regression when switching to System.Text.Json when writing the buffer back out.
