### PR TITLE
Force Keyboard focus

### DIFF
--- a/Code/XTMF.Gui/UserControls/SelectRunDateTimeDialog.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/SelectRunDateTimeDialog.xaml.cs
@@ -46,7 +46,7 @@ namespace XTMF.Gui.UserControls
         private DialogSession _dialogSession;
 
         public bool DidComplete { get; set; }
-    
+  
         public SelectRunDateTimeDialog(ModelSystemEditingSession session)
         {
             InitializeComponent();
@@ -70,13 +70,28 @@ namespace XTMF.Gui.UserControls
         /// <returns></returns>
         public async Task<object> ShowAsync(DialogHost host = null)
         {
-            return await (host == null ? DialogHost.Show(this, "RootDialog", OpenedEventHandler, ClosingEventHandler)
-                : host.ShowDialog(this, OpenedEventHandler, ClosingEventHandler));
+            var previousKeyboardFocus = Keyboard.FocusedElement;
+            Keyboard.ClearFocus();
+            try
+            {
+                return await (host == null ? DialogHost.Show(this, "RootDialog", OpenedEventHandler, ClosingEventHandler)
+                    : host.ShowDialog(this, OpenedEventHandler, ClosingEventHandler));
+            }
+            finally
+            {
+                Keyboard.Focus(previousKeyboardFocus);
+            }
         }
 
         private void OpenedEventHandler(object sender, DialogOpenedEventArgs eventargs)
         {
             _dialogSession = eventargs.Session;
+        }
+
+        protected override void OnGotFocus(RoutedEventArgs e)
+        {
+            base.OnGotFocus(e);
+            Keyboard.Focus(StringInputTextBox);
         }
 
         /// <summary>


### PR DESCRIPTION
This change changes the keyboard focus to make sure that when the user selects to run a model system it clears the keyboard focus to make sure that a quick up or down arrow won't steal the focus away before teh dialog animation finishes.
