### PR TITLE
Fix model system reflection when in debug mode.

### DIFF
--- a/Code/TMG.Functions/ModelSystemReflection.cs
+++ b/Code/TMG.Functions/ModelSystemReflection.cs
@@ -371,7 +371,7 @@ namespace TMG.Functions
             List<IModelSystemStructure> chain = new List<IModelSystemStructure>();
             foreach (var ms in project.ModelSystemStructure)
             {
-                if (BuildModelStructureChain(ms, toFind, chain))
+                if (ms is not null && BuildModelStructureChain(ms, toFind, chain))
                 {
                     break;
                 }
@@ -390,7 +390,7 @@ namespace TMG.Functions
             List<IModelSystemStructure> chain = new List<IModelSystemStructure>();
             foreach (var ms in config.ProjectRepository.ActiveProject.ModelSystemStructure)
             {
-                if (BuildModelStructureChain(ms, toFind, chain))
+                if (ms is not null && BuildModelStructureChain(ms, toFind, chain))
                 {
                     break;
                 }
@@ -407,6 +407,10 @@ namespace TMG.Functions
         /// <returns>True if we found the module, false otherwise</returns>
         public static bool BuildModelStructureChain(IModelSystemStructure root, IModule toFind, List<IModelSystemStructure> chain)
         {
+            if(root is null)
+            {
+                return false;
+            }
             if (root.Module == toFind)
             {
                 chain.Add(root);
@@ -436,6 +440,10 @@ namespace TMG.Functions
         /// <returns>True if we found the module, false otherwise</returns>
         public static bool BuildModelStructureChain(IModelSystemStructure root, IModelSystemStructure toFind, List<IModelSystemStructure> chain)
         {
+            if (root is null)
+            {
+                return false;
+            }
             if (root == toFind)
             {
                 chain.Add(root);
@@ -465,6 +473,10 @@ namespace TMG.Functions
         /// <returns>True if a model system structure with that path was found, false otherwise</returns>
         public static bool GetModelSystemStructureFromPath(IModelSystemStructure root, string path, ref IModelSystemStructure structure)
         {
+            if (root is null)
+            {
+                return false;
+            }
             var parts = SplitNameToParts(path);
             IModelSystemStructure current = root;
             for (int i = 0; i < parts.Length; i++)

--- a/Tasha/TashaRuntime.cs
+++ b/Tasha/TashaRuntime.cs
@@ -288,12 +288,17 @@ namespace Tasha
 
         private bool FindUs(IModelSystemStructure mst, ref IModelSystemStructure modelSystemStructure)
         {
+            // Defend against model systems that have not been loaded.
+            if(mst is null)
+            {
+                return false;
+            }
             if (mst.Module == this)
             {
                 modelSystemStructure = mst;
                 return true;
             }
-            if (mst.Children != null)
+            if (mst.Children is not null)
             {
                 foreach (var child in mst.Children)
                 {


### PR DESCRIPTION
Currently if you run a model system that uses model system reflection it can run into issues if the model system that is currently running is not loaded already.  This only is an issue when running XTMF with a debugger attached.