### PR TITLE
Fix ParkingCost

### DIFF
--- a/Tasha/Common/ParkingModel.cs
+++ b/Tasha/Common/ParkingModel.cs
@@ -142,6 +142,11 @@ namespace Tasha.Common
                             reader.Get(out data.Nightly.Hourly, 5);
                             reader.Get(out data.Nightly.Max, 6);
                             reader.Get(out data.FullDayMax, 7);
+
+                            // Convert from hourly costs to per minute costs
+                            data.Daily.Hourly /= 60;
+                            data.Nightly.Hourly /= 60;
+
                             _parkingInformation[index] = data;
                         }
                     }


### PR DESCRIPTION
Previously the hourly costs were loaded in as such however when we compute with them they are competed against minutes.  This fix transforms the inputs into per minute costs.