### PR TITLE
Fix XTMF.Run to work with new Delayed Project Loading

### DIFF
--- a/Code/XTMF.Run/Program.cs
+++ b/Code/XTMF.Run/Program.cs
@@ -61,7 +61,7 @@ namespace XTMF.Run
             }
             using (var projectSession = runtime.ProjectController.EditProject(project))
             {
-                var modelSystems = projectSession.Project.ModelSystemStructure.Select((m, i) => new { MSS = m, Index = i }).Where((m, i) => m.MSS.Name == modelSystemName).ToList();
+                var modelSystems = projectSession.Project.ProjectModelSystems.Select((m, i) => new { MSS = m, Index = i }).Where((m, i) => m.MSS.Name == modelSystemName).ToList();
                 switch (modelSystems.Count)
                 {
                     case 0:


### PR DESCRIPTION
The previous implementation would use the model system structure name to find the model system to run.  This of course no longer works because we don't populate those until the model system is loaded.  It will instead now use the ProjectModelSystem list to find the name of the model system to execute.
