### PR TITLE
Parameter Fixes

### DIFF
--- a/Code/XTMF.Gui/MainWindow.xaml.cs
+++ b/Code/XTMF.Gui/MainWindow.xaml.cs
@@ -432,7 +432,7 @@ namespace XTMF.Gui
             if (Ookii.Dialogs.Wpf.VistaFolderBrowserDialog.IsVistaFolderDialogSupported)
             {
                 var dialog = new Ookii.Dialogs.Wpf.VistaFolderBrowserDialog();
-                if (dialog.ShowDialog(MainWindow.Us).HasValue)
+                if (dialog.ShowDialog(MainWindow.Us) == true)
                 {
                     return dialog.SelectedPath;
                 }

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml
@@ -107,7 +107,7 @@
                                            GotKeyboardFocus="ParameterValueTextBox_OnGotKeyboardFocus" CaretBrush="{DynamicResource SecondaryHueDarkBrush}"
                                           Margin="4,0,0,0" HorizontalAlignment="Stretch" Text="{Binding Value, NotifyOnSourceUpdated=True}" FocusManager.IsFocusScope="True"
                                           PreviewKeyDown="HintedTextBox_PreviewKeyDown" Foreground="{DynamicResource MaterialDesignBody}" Drop="StandardParameterTemplateTextBox_OnDrop"
-                                          SelectionOpacity="1" MinHeight="15" LostKeyboardFocus="TextBox_OnLostKeyboardFocus"
+                                          MinHeight="15" LostKeyboardFocus="TextBox_OnLostKeyboardFocus"
                                    ContextMenu="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=ContextMenu}"/>
 
                         <StackPanel Grid.Row="1" materialDesign:TransitionAssist.DisableTransitions="True"   Grid.Column="0" Orientation="Vertical" VerticalAlignment="Center">

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -1799,7 +1799,7 @@ namespace XTMF.Gui.UserControls
             if (GetCurrentParameterDisplayModelContext() is ParameterDisplayModel currentParameter)
             {
                 var inputParameter =
-                    GetInputParameter(ActiveModelSystemView.SelectedModule.BaseModel,
+                    GetInputParameter((ActiveModelSystemView.SelectedModule ?? DisplayRoot).BaseModel,
                         out var inputDirectory);
                 if (inputParameter is not null)
                 {

--- a/Code/XTMF.Gui/XTMF.Gui.csproj
+++ b/Code/XTMF.Gui/XTMF.Gui.csproj
@@ -125,6 +125,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
 	</ItemGroup>
 	<ItemGroup>
 	  <Compile Update="Properties\Settings.Designer.cs">


### PR DESCRIPTION
- Fixed cancelled directory select setting the value to an empty string.
- Fixed trying to open a parameter as a file, or its directory before selecting a module.
- Fixed textbox selection opacity.
