### PR TITLE
Fixed TASHA report durations and mode choice

### DIFF
--- a/Code/Tasha.Validation/Report/Analyses/ActivityDurationByPurpose.cs
+++ b/Code/Tasha.Validation/Report/Analyses/ActivityDurationByPurpose.cs
@@ -44,23 +44,13 @@ public sealed class ActivityDurationByPurpose : Analysis
     public override void Execute(TimePeriod[] timePeriods, MicrosimData microsimData, ITashaHousehold[] surveyHouseholdsWithTrips)
     {
         using var streamWriter = new StreamWriter(SaveTo);
-        streamWriter.WriteLine("Duration,Purpose,Observed,Model,Model-Observed");
-
-        static string GetMinutes(int i) =>
-            (i & 0x3) switch
-            {
-                0 => "00",
-                1 => "15",
-                2 => "30",
-                3 => "45",
-                _ => "00"
-            };
+        streamWriter.WriteLine("Duration(Minutes),Purpose,Observed,Model,Model-Observed");
 
         for (int j = 0; j < PurposeGroup.Length; j++)
         {
             for (int i = 1; i < 96; i++)
             {
-                var time = $"{i >> 2}:{GetMinutes(i)}";
+                var time = i * 15;
                 var observed = ComputeObserved(surveyHouseholdsWithTrips, i, PurposeGroup[j]);
                 var model = ComputeModel(microsimData, i * 15.0f, PurposeGroup[j]);
                 streamWriter.WriteLine($"{time},{PurposeGroup[j].Name},{observed},{model},{model - observed}");

--- a/Code/Tasha.Validation/Report/Analyses/ModesByDestinationByTimeOfDay.cs
+++ b/Code/Tasha.Validation/Report/Analyses/ModesByDestinationByTimeOfDay.cs
@@ -118,6 +118,7 @@ public sealed class ModesByDestinationByTimeOfDay : Analysis
                     {
                         continue;
                     }
+                    var expansionFactor = person.ExpansionFactor;
                     foreach (var tripChain in person.TripChains)
                     {
                         foreach (var trip in tripChain.Trips)
@@ -141,7 +142,7 @@ public sealed class ModesByDestinationByTimeOfDay : Analysis
                                 continue;
                             }
                             var index = (timeIndex * pds.Length * ModeGroups.Length) + (pdIndex * ModeGroups.Length) + modeIndex;
-                            local[index]++;
+                            local[index] += expansionFactor;
                         }
                     }
                 }

--- a/Code/Tasha.Validation/Report/Analyses/ModesByOriginByTimeOfDay.cs
+++ b/Code/Tasha.Validation/Report/Analyses/ModesByOriginByTimeOfDay.cs
@@ -118,6 +118,7 @@ public sealed class ModesByOriginByTimeOfDay : Analysis
                     {
                         continue;
                     }
+                    var expansionFactor = person.ExpansionFactor;
                     foreach (var tripChain in person.TripChains)
                     {
                         foreach (var trip in tripChain.Trips)
@@ -141,7 +142,7 @@ public sealed class ModesByOriginByTimeOfDay : Analysis
                                 continue;
                             }
                             var index = timeIndex * pds.Length * ModeGroups.Length + pdIndex * ModeGroups.Length + modeIndex;
-                            local[index]++;
+                            local[index] += person.ExpansionFactor;
                         }
                     }
                 }


### PR DESCRIPTION
In the current implementation we were getting the counts from the observed modes instead of the expanded total.  This patch fixes that.

The way durations are displayed have now also been changed so that it is reported in the number of minutes to avoid issues with excel.