### PR TITLE
Fixed Linked Parameters not being saved during a model run.

### DIFF
--- a/Code/XTMF/Editing/ModelSystemEditingSession.cs
+++ b/Code/XTMF/Editing/ModelSystemEditingSession.cs
@@ -344,10 +344,10 @@ public sealed class ModelSystemEditingSession : IDisposable
                                 : XTMFRun.CreateRemoteHost(cloneProject, _ModelSystemIndex, ModelSystemModel,
                                     Runtime.Configuration, runName, overwrite);
                     }
-                    run.ProjectSavedByRun += (theRun, newMSS) =>
+                    run.ProjectSavedByRun += (theRun, newMSS, linkedParameters) =>
                     {
                         string e = null;
-                        ProjectEditingSession.Project.UpdateModelSystemStructure(_ModelSystemIndex, newMSS);
+                        ProjectEditingSession.Project.UpdateModelSystemStructure(_ModelSystemIndex, newMSS, linkedParameters);
                         ProjectEditingSession.Project.Save(ref e);
                         Reload();
                         ProjectWasExternallySaved?.Invoke(this, new ProjectWasExternallySavedEventArgs(ModelSystemModel));

--- a/Code/XTMF/Project.cs
+++ b/Code/XTMF/Project.cs
@@ -605,14 +605,15 @@ public sealed partial class Project : IProject
     /// </summary>
     /// <param name="modelSystemIndex"></param>
     /// <param name="newMSS"></param>
-    public void UpdateModelSystemStructure(int modelSystemIndex, ModelSystemStructure newMSS)
+    public void UpdateModelSystemStructure(int modelSystemIndex, ModelSystemStructure newMSS, List<ILinkedParameter> linkedParameters)
     {
         if (modelSystemIndex < 0 || modelSystemIndex >= ProjectModelSystems.Count)
         {
             throw new ArgumentOutOfRangeException(nameof(modelSystemIndex));
         }
-
+        // Fix the linked parameters before swapping in the new model system structure
         ProjectModelSystems[modelSystemIndex].Root = newMSS;
+        ProjectModelSystems[modelSystemIndex].LinkedParameters = linkedParameters;
     }
 
     /// <summary>
@@ -1589,8 +1590,13 @@ public sealed partial class Project : IProject
         return true;
     }
 
-
-    private string LookupName(IModuleParameter reference, IModelSystemStructure current)
+    /// <summary>
+    /// Get the path for a given parameter
+    /// </summary>
+    /// <param name="reference">The parameter to find.</param>
+    /// <param name="current">The starting point in the model system to refer from.</param>
+    /// <returns>The path to the parameter separated by periods.</returns>
+    public static string LookupName(IModuleParameter reference, IModelSystemStructure current)
     {
         var param = current.Parameters;
         if (param != null)

--- a/Code/XTMF/Run/XTMFRunRemoteClient.cs
+++ b/Code/XTMF/Run/XTMFRunRemoteClient.cs
@@ -46,7 +46,7 @@ sealed class XTMFRunRemoteClient : XTMFRun
             ((ProjectRepository)(configuration.ProjectRepository)).SetActiveProject(temp);
             temp.ExternallySaved += (o, e) =>
             {
-                SendProjectSaved(null);
+                SendProjectSaved(null, null);
             };
             var msAsBytes = Encoding.Unicode.GetBytes(modelSystemString);
             memStream.Write(msAsBytes, 0, msAsBytes.Length);
@@ -56,6 +56,7 @@ sealed class XTMFRunRemoteClient : XTMFRun
             _Root = (ModelSystemStructure)mss;
             _linkedParameters = LoadLinkedParameters(_Root, memStream);
             temp.AddModelSystem(_Root, _linkedParameters, String.Empty);
+            LinkedParameters = _linkedParameters;
         }
         catch (Exception e)
         {

--- a/Code/XTMF/XTMFRun.cs
+++ b/Code/XTMF/XTMFRun.cs
@@ -51,6 +51,11 @@ public abstract class XTMFRun : IDisposable
     /// </summary>
     public ModelSystemStructureModel ModelSystemStructureModelRoot { get; protected set; }
 
+    /// <summary>
+    /// The linked parameters that are currently being used
+    /// </summary>
+    public List<ILinkedParameter> LinkedParameters { get; protected set; }
+
     public string RunDirectory { get; private set; }
 
     public abstract bool RunsRemotely { get; }
@@ -180,7 +185,7 @@ public abstract class XTMFRun : IDisposable
     /// <summary>
     /// An event the fires when the running project has saved itself
     /// </summary>
-    public event Action<XTMFRun, ModelSystemStructure> ProjectSavedByRun;
+    public event Action<XTMFRun, ModelSystemStructure, List<ILinkedParameter>> ProjectSavedByRun;
 
     /// <summary>
     /// Attempt to ask the model system to exit.
@@ -375,8 +380,8 @@ public abstract class XTMFRun : IDisposable
         }
     }
 
-    protected void SendProjectSaved(ModelSystemStructure mss)
+    protected void SendProjectSaved(ModelSystemStructure mss, List<ILinkedParameter> linkedParameters)
     {
-        ProjectSavedByRun?.Invoke(this, mss);
+        ProjectSavedByRun?.Invoke(this, mss, linkedParameters);
     }
 }


### PR DESCRIPTION
This lets automatic calibration work without breaking all of the linked parameters.