### PR TITLE
Load Microsim Observed Mode

### DIFF
--- a/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
+++ b/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
@@ -143,14 +143,14 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
         () => personsRecords = MicrosimPerson.LoadPersons(this, PersonFile),
         () =>
         {
-            if (TripFile != null)
+            if (TripFile is not null)
             {
                 tripRecords = MicrosimTrip.LoadTrips(this, TripFile);
             }
         },
         () =>
         {
-            if (ModeFile != null)
+            if (ModeFile is not null)
             {
                 modeRecords = MicrosimTripMode.LoadModes(this, ModeFile);
             }
@@ -236,6 +236,9 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
     [RunParameter("Household Iterations", 10, "Set this to the same number of iterations that the mode choice algorithm will use.")]
     public int HouseholdIterations;
 
+    [RunParameter("Mode Attribute", "", "An optional attribute name to give to the first observed mode.")]
+    public string ModeAttribute;
+
     private ITrip ConstructTrip(MicrosimTrip trip, TripChain tc, SparseArray<IZone> zoneSystem, MicrosimTripMode modeData)
     {
         IZone origin = GetZone(zoneSystem, trip.OriginZone, "origin");
@@ -251,6 +254,10 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             ret.TripStartTime = startTime;
             ret.TripChain = tc;
             ret.TripNumber = trip.TripID;
+            if (!string.IsNullOrWhiteSpace(ModeAttribute))
+            {
+                ret.Attach(ModeAttribute, modeData.Mode);
+            }
             return ret;
         }
         else
@@ -263,6 +270,10 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             ret.ActivityStartTime = startTime;
             ret.TripChain = tc;
             ret.TripNumber = trip.TripID;
+            if (!string.IsNullOrWhiteSpace(ModeAttribute))
+            {
+                ret.Attach(ModeAttribute, modeData.Mode);
+            }
             return ret;
         }
     }
@@ -538,7 +549,7 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             error = $"In {Name} either both the Trip file and Mode file need to be selected for or not.";
             return false;
         }
-        if(TelecommutingModel is not null && String.IsNullOrWhiteSpace(TelecommuterAttribute))
+        if (TelecommutingModel is not null && String.IsNullOrWhiteSpace(TelecommuterAttribute))
         {
             error = $"In {Name} you must specify the attribute to store the telecommuter choice to when using the telecommuting model!";
             return false;

--- a/TorontoHouseholds/MicrosimLoader/MicrosimTripMode.cs
+++ b/TorontoHouseholds/MicrosimLoader/MicrosimTripMode.cs
@@ -1,5 +1,5 @@
 ﻿/*
-    Copyright 2021 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+    Copyright 2021-2024 Travel Modelling Group, Department of Civil Engineering, University of Toronto
 
     This file is part of XTMF.
 
@@ -42,6 +42,10 @@ internal sealed class MicrosimTripMode
     /// </summary>
     internal readonly int TripID;
     /// <summary>
+    /// The mode of the trip
+    /// </summary>
+    internal readonly string Mode;
+    /// <summary>
     /// The start time of the trip.
     /// </summary>
     internal readonly float DepartureTime;
@@ -50,11 +54,12 @@ internal sealed class MicrosimTripMode
     /// </summary>
     internal readonly float ArrivalTime;
 
-    private MicrosimTripMode(int householdID, int personID, int tripID, float departureTime, float arrivalTime)
+    private MicrosimTripMode(int householdID, int personID, int tripID, string mode, float departureTime, float arrivalTime)
     {
         HouseholdID = householdID;
         PersonID = personID;
         TripID = tripID;
+        Mode = mode;
         DepartureTime = departureTime;
         ArrivalTime = arrivalTime;
     }
@@ -84,12 +89,13 @@ internal sealed class MicrosimTripMode
                     reader.Get(out int householdID, 0);
                     reader.Get(out int personID, 1);
                     reader.Get(out int tripID, 2);
+                    reader.Get(out string mode, 3);
                     reader.Get(out float departureTime, 4);
                     reader.Get(out float arrivalTime, 5);
                     // We only need to get 1 of these records
                     if (!ret.ContainsKey((householdID, personID, tripID)))
                     {
-                        ret[(householdID, personID, tripID)] = new MicrosimTripMode(householdID, personID, tripID, departureTime, arrivalTime);
+                        ret[(householdID, personID, tripID)] = new MicrosimTripMode(householdID, personID, tripID, mode, departureTime, arrivalTime);
                     }
                 }
             }


### PR DESCRIPTION
Lets you load in the assigned mode to an attached attribute for each trip.  This logically works if there was a single household iteration executed.