### PR TITLE
Added Calibration Modules

### DIFF
--- a/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
+++ b/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
@@ -19,8 +19,6 @@
 using Datastructure;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using TMG.Functions;
 using XTMF;
@@ -65,7 +63,7 @@ public sealed class ProbabilityMatrixTarget : CalibrationTarget
     private float _baseRunProbability = float.NegativeInfinity;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProbabilityMatrixTarget"/> class.
+    /// Called by XTMF
     /// </summary>
     /// <param name="config">The configuration.</param>
     public ProbabilityMatrixTarget(IConfiguration config) : base(config)

--- a/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
+++ b/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
@@ -1,0 +1,170 @@
+﻿/*
+    Copyright 2024 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Datastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TMG.Functions;
+using XTMF;
+
+namespace TMG.Estimation.Calibration;
+
+/// <summary>
+/// This module is designed to represent a probability matrix target for calibration.
+/// </summary>
+[ModuleInformation(Description = "This module is designed to update a constant")]
+public sealed class ProbabilityMatrixTarget : CalibrationTarget
+{
+    /// <summary>
+    /// The minimum value allowed for this parameter.
+    /// </summary>
+    [RunParameter("Minimum Value", float.NegativeInfinity, "The lowest value allowed for this parameter.")]
+    public float MinimumValue;
+
+    /// <summary>
+    /// The maximum value allowed for this parameter.
+    /// </summary>
+    [RunParameter("Maximum Value", float.PositiveInfinity, "The highest value allowed for this parameter.")]
+    public float MaximumValue;
+
+    [SubModelInformation(Required = true, Description = "The total matrix from the observed.")]
+    public IDataSource<SparseTwinIndex<float>> ObservedTotal;
+
+    [SubModelInformation(Required = true, Description = "The selected matrix from the observed.")]
+    public IDataSource<SparseTwinIndex<float>> ObservedSelection;
+
+    [SubModelInformation(Required = true, Description = "The total matrix from the model.")]
+    public IDataSource<SparseTwinIndex<float>> ModelTotal;
+
+    [SubModelInformation(Required = true, Description = "The selected matrix from the model.")]
+    public IDataSource<SparseTwinIndex<float>> ModelSelection;
+
+    [SubModelInformation(Required = false, Description = "A mask matrix to apply to the matrices.")]
+    public IDataSource<SparseTwinIndex<float>> Mask;
+
+    private float[][] _mask = null!;
+    private float _targetProbability = float.NegativeInfinity;
+    private float _baseRunProbability = float.NegativeInfinity;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProbabilityMatrixTarget"/> class.
+    /// </summary>
+    /// <param name="config">The configuration.</param>
+    public ProbabilityMatrixTarget(IConfiguration config) : base(config)
+    {
+    }
+
+    /// <summary>
+    /// Updates the parameter value based on the current value.
+    /// </summary>
+    /// <param name="currentValue">The current value of the parameter.</param>
+    /// <returns>The updated value of the parameter.</returns>
+    public override float UpdateParameter(float currentValue)
+    {
+        var numerator = _targetProbability * _baseRunProbability - _targetProbability;
+        var denominator = _baseRunProbability * _targetProbability - _baseRunProbability;
+
+        var delta = MathF.Log(numerator / denominator);
+        if (!float.IsFinite(delta))
+        {
+            Console.WriteLine($"We found an invalid step size for {Name}!");
+            return currentValue;
+        }
+        return ClampValue(currentValue + delta, MinimumValue, MaximumValue);
+    }
+
+    /// <summary>
+    /// Loads the target data.
+    /// </summary>
+    protected override void LoadTarget()
+    {
+        _mask = Mask is not null ? GetValue(Mask).GetFlatData() : null;
+        _targetProbability = GetValue(ObservedTotal, ObservedSelection);
+    }
+
+    /// <summary>
+    /// Stores the run data.
+    /// </summary>
+    /// <param name="runIndex">The index of the run.</param>
+    internal override void StoreRun(int runIndex)
+    {
+        _baseRunProbability = GetValue(ModelTotal, ModelSelection);
+    }
+
+    private static SparseTwinIndex<float> GetValue(IDataSource<SparseTwinIndex<float>> source)
+    {
+        source.LoadData();
+        var ret = source.GiveData();
+        source.UnloadData();
+        return ret;
+    }
+
+    private float GetValue(IDataSource<SparseTwinIndex<float>> totalSource, IDataSource<SparseTwinIndex<float>> selectionSource)
+    {
+        SparseTwinIndex<float> total = null;
+        SparseTwinIndex<float> selection = null;
+        float sumTotal = float.NegativeInfinity;
+        float sumSelection = float.NegativeInfinity;
+        Parallel.Invoke(
+            () => total = GetValue(totalSource),
+            () => selection = GetValue(selectionSource)
+        );
+        Parallel.Invoke(
+            () => sumTotal = GetMaskedSum(total),
+            () => sumSelection = GetMaskedSum(selection)
+        );
+        return sumSelection / sumTotal;
+    }
+
+    private float GetMaskedSum(SparseTwinIndex<float> matrix)
+    {
+        float acc = 0.0f;
+        var data = matrix.GetFlatData();
+        if (_mask is null)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                acc += VectorHelper.Sum(data[i], 0, data.Length);
+            }
+            return acc;
+        }
+        else
+        {
+            var mask = _mask;
+            for (int i = 0; i < data.Length; i++)
+            {
+                acc += VectorHelper.MultiplyAndSumNoStore(data[i], mask[i]);
+            }
+            return acc;
+        }
+    }
+
+    internal override float ReportTargetDistance()
+    {
+        return _baseRunProbability - _targetProbability;
+    }
+
+    public override IEnumerable<ParameterSetting[]> CreateAdditionalRuns(ParameterSetting[] baseParameters, int iteration, int targetIndex)
+    {
+        yield break;
+    }
+
+}

--- a/Code/TMG.Frameworks/Data/Loading/ZoneSystemMaskMatrix.cs
+++ b/Code/TMG.Frameworks/Data/Loading/ZoneSystemMaskMatrix.cs
@@ -1,0 +1,175 @@
+﻿/*
+    Copyright 2016-2017 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Datastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XTMF;
+
+namespace TMG.Frameworks.Data.Loading;
+
+[ModuleInformation(Description = "This module create a mask matrix for different selected origins and destination combinations." +
+    " To be selected the cell must be both contained within the origins and destinations.")]
+public sealed class ZoneSystemMaskMatrix : IDataSource<SparseTwinIndex<float>>
+{
+    [RunParameter("Origins", "1", typeof(RangeSet), "The range of origin values to include in the mask.")]
+    public RangeSet Origins;
+
+    [RunParameter("Destinations", "1", typeof(RangeSet), "The range of destination values to include in the mask.")]
+    public RangeSet Destinations;
+
+    private SparseTwinIndex<float> _data = null;
+
+    [SubModelInformation(Required = false, Description = "An optional zone system to use. If not selected the Root zone system will be used.")]
+    public IDataSource<SparseArray<IZone>> ZoneSystem;
+
+    public bool Loaded => _data is not null;
+
+    public enum FillData
+    {
+        ZoneNumber,
+        PlanningDistrict,
+        Region,
+        FlatIndex
+    }
+
+    public FillData FillWith;
+
+    private IConfiguration _config;
+
+    public ZoneSystemMaskMatrix(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public void LoadData()
+    {
+        SparseArray<IZone> zoneSystem = GetZoneSystem();
+        int[] intVector = GetSpatialIndexes(zoneSystem);
+        var data = zoneSystem.CreateSquareTwinArray<float>();
+        var flatData = data.GetFlatData();
+        System.Threading.Tasks.Parallel.For(0, intVector.Length, (i) =>
+        {
+            // No need to process if this is not an origin
+            if (!Origins.Contains(intVector[i]))
+            {
+                return;
+            }
+            var row = flatData[i];
+            for (int j = 0; j < row.Length; j++)
+            {
+                row[j] = Destinations.Contains(intVector[j]) ? 1.0f : 0.0f;
+            }
+        });
+        _data = data;
+    }
+
+    [DoNotAutomate]
+    private ITravelDemandModel _root;
+
+    private SparseArray<IZone> GetZoneSystem()
+    {
+        if (_root is not null)
+        {
+            var zoneSystem = _root.ZoneSystem;
+            var loaded = zoneSystem.Loaded;
+            if (!loaded)
+            {
+                zoneSystem.LoadData();
+            }
+            var ret = zoneSystem.GiveData().ZoneArray;
+            if (!loaded)
+            {
+                zoneSystem.UnloadData();
+            }
+            return ret;
+        }
+        else
+        {
+            var loaded = ZoneSystem.Loaded;
+            if (!loaded)
+            {
+                ZoneSystem.LoadData();
+            }
+            var ret = ZoneSystem.GiveData();
+            if (!loaded)
+            {
+                ZoneSystem.UnloadData();
+            }
+            return ret;
+        }
+    }
+
+    private int[] GetSpatialIndexes(SparseArray<IZone> zonesSystem)
+    {
+        return FillWith switch
+        {
+            FillData.PlanningDistrict => zonesSystem.GetFlatData().Select(z => z.PlanningDistrict).ToArray(),
+            FillData.Region => zonesSystem.GetFlatData().Select(z => z.RegionNumber).ToArray(),
+            FillData.FlatIndex => Enumerable.Range(0, zonesSystem.GetFlatData().Length).ToArray(),
+            FillData.ZoneNumber => zonesSystem.GetFlatData().Select(z => z.ZoneNumber).ToArray(),
+            _ => throw new XTMFRuntimeException(this, "Unknown FillData Type!")
+        };
+    }
+
+    public SparseTwinIndex<float> GiveData()
+    {
+        return _data;
+    }
+
+    public void UnloadData()
+    {
+        _data = null;
+    }
+
+    public string Name { get; set; }
+
+    public float Progress => 0f;
+
+    public Tuple<byte, byte, byte> ProgressColour => new(50, 150, 50);
+
+    public bool RuntimeValidation(ref string error)
+    {
+        if (ZoneSystem is not null)
+        {
+            // No need to find a root if we have a source already.
+            return true;
+        }
+        // Find our source of the zone system
+        if (!TMG.Functions.ModelSystemReflection.GetRootOfType(_config, typeof(ITravelDemandModel), this, out var root))
+        {
+            error = $"Could not find a root of type {typeof(ITravelDemandModel).FullName} and there was no ZoneSystem provided!";
+            return false;
+        }
+        if(root.Module is ITravelDemandModel model)
+        {
+            _root = model;
+        }
+        else
+        {
+            // This should never happen
+            error = "We were not able to get out an ITravelDemandModel after reflecting a found root of that type!";
+            return false;
+        }
+        return true;
+    }
+}
+


### PR DESCRIPTION
ProbabilityMatrixTarget - Simplifies creating a ratio given totals for the observed, and the subselection with an option to apply a mask.
ZoneSystemMaskMatrix - Allows you to create mask matrices without requiring an ITravelDemandModel root, meant to be used in conjuntion with ProbabilityMatrixTarget
