### PR TITLE
Lookup Input Directory value using the default parameter name.

### DIFF
--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -1911,7 +1911,7 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
             var parameters = root.Parameters.GetParameters();
             for (var i = 0; i < parameters.Count; i++)
             {
-                if (parameters[i].Name == parameterName)
+                if (parameters[i].DefaultName == parameterName)
                 {
                     parameter = parameters[i];
                     return parameters[i].Value;

--- a/Code/XTMF/Editing/ParameterModel.cs
+++ b/Code/XTMF/Editing/ParameterModel.cs
@@ -89,6 +89,8 @@ public class ParameterModel : INotifyPropertyChanged
 
     public string Name => RealParameter.Name;
 
+    public string DefaultName => RealParameter.NameOnModule;
+
     private string _Value;
 
     public string Value


### PR DESCRIPTION
Currently if someone renamed "Input Directory" from the IModelSystemTemplate it won't be found.  This fix uses the default name of parameters instead of the current names when searching for the parameter.
