### PR TITLE
Limit selected modules to visable ones

### DIFF
--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml.cs
@@ -741,10 +741,14 @@ public partial class ModelSystemTreeViewDisplay : UserControl, IModelSystemView,
                     {
                         var innerTreeViewItem = itemGenerator.ContainerFromIndex(i) as TreeViewItem;
                         var innerModule = itemGenerator.Items[i] as ModelSystemStructureDisplayModel;
+                        
                         CurrentlySelected.Remove(innerModule);
-
-                        CurrentlySelected.Add(innerModule);
-                        selectedItems.Add(innerTreeViewItem);
+                        // Make sure that the item has not been filtered out
+                        if (innerModule.ModuleVisibility == Visibility.Visible)
+                        {
+                            CurrentlySelected.Add(innerModule);
+                            selectedItems.Add(innerTreeViewItem);
+                        }
                     }
                 }
 


### PR DESCRIPTION
In the current implementation if you shift-click while using a module filter, modules between
the start and stop points will be selected even if they have been filtered out.  This patch
only allows a module to be selected if it is currently visable.
