### PR TITLE
Implement clone for modules in collections.

### DIFF
--- a/Code/XTMF.Gui/Models/ModelSystemStructureDisplayModel.cs
+++ b/Code/XTMF.Gui/Models/ModelSystemStructureDisplayModel.cs
@@ -300,6 +300,36 @@ public class ModelSystemStructureDisplayModel : INotifyPropertyChanged
         Clipboard.SetDataObject(ModelSystemStructureModel.CopyModule(toCopy.Select(m => m.BaseModel).ToList()));
     }
 
+    internal static bool CloneModules(ModelSystemEditingSession session, List<ModelSystemStructureDisplayModel> toClone, ref string error)
+    {
+        List<string> errors = [];
+        session.ExecuteCombinedCommands("Clone", () => 
+        {
+            var inner = toClone.Select(m => m.BaseModel).ToList();
+            foreach (var toProcess in inner)
+            {
+                var parent = session.GetParent(toProcess);
+                if(parent is null || !parent.IsCollection)
+                {
+                    errors.Add("You can only clone modules inside of a collection. ");
+                    break;
+                }
+                string e = null;
+                if(!parent.Paste(session, toProcess.CopyModule(), ref e))
+                {
+                    errors.Add(e);
+                    break;
+                }
+            }
+        });
+        if(errors.Count > 0)
+        {
+            error = string.Join("\n", errors);
+            return false;
+        }
+        return true;
+    }
+
     internal bool Paste(ModelSystemEditingSession session, string toPaste, ref string error)
     {
         return BaseModel.Paste(session, toPaste, ref error);

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -1328,6 +1328,17 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
 
     /// <summary>
     /// </summary>
+    public void CloneCurrentModule()
+    {
+        string error = null;
+        if (!ModelSystemStructureDisplayModel.CloneModules(Session, CurrentlySelected, ref error))
+        {
+            MessageBox.Show(error, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    /// <summary>
+    /// </summary>
     public void PasteCurrentModule()
     {
         var pasteText = Clipboard.GetText();
@@ -1698,7 +1709,7 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
 
             // Make sure there is enough room
 
-            if(startingIndex + text.Length > currentParameterDisplay.Items.Count)
+            if (startingIndex + text.Length > currentParameterDisplay.Items.Count)
             {
                 MessageBox.Show(GetWindow(), "There is not enough space to paste all of the entries.");
                 return;

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay_EventHandlers.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay_EventHandlers.xaml.cs
@@ -106,7 +106,14 @@ public partial class ModelSystemDisplay
                     e.Handled = true;
                     break;
                 case Key.C:
-                    CopyCurrentModule();
+                    if (EditorController.IsShiftDown())
+                    {
+                        CloneCurrentModule();
+                    }
+                    else
+                    {
+                        CopyCurrentModule();
+                    }
                     e.Handled = true;
                     break;
                 case Key.V:
@@ -122,7 +129,6 @@ public partial class ModelSystemDisplay
                     else
                     {
                         ToggleQuickParameterDisplaySearch();
-
                         e.Handled = true;
                         break;
                     }

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml
@@ -173,6 +173,11 @@
                                     <materialDesign:PackIcon Kind="ContentCopy" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                                 </MenuItem.Icon>
                             </MenuItem>
+                            <MenuItem Name="CloneMenuItem"  Header="Clone (Ctrl+Shift+C)" Click="CloneMenuItem_OnClick" >
+                                <MenuItem.Icon>
+                                    <materialDesign:PackIcon Kind="FileDocumentAdd" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                </MenuItem.Icon>
+                            </MenuItem>
                             <MenuItem Name="PastMenuItem"  Header="Paste (Ctrl+V)" Click="PastMenuItem_OnClick" >
                                 <MenuItem.Icon>
                                     <materialDesign:PackIcon Kind="ContentPaste" VerticalAlignment="Center" HorizontalAlignment="Center"/>

--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemTreeViewDisplay.xaml.cs
@@ -235,6 +235,10 @@ public partial class ModelSystemTreeViewDisplay : UserControl, IModelSystemView,
                             menuItem.IsEnabled = false;
                         }
                     }
+                    else if(menuItem.Name == nameof(CloneMenuItem))
+                    {
+                        menuItem.IsEnabled = treeViewItem.BackingModel.Parent?.IsCollection ?? false;
+                    }
                     else if (menuItem.Name == "ModuleMenuItem")
                     {
                         menuItem.Header = treeViewItem.BackingModel.BaseModel.IsCollection
@@ -879,6 +883,15 @@ public partial class ModelSystemTreeViewDisplay : UserControl, IModelSystemView,
     private void CopyMenuItem_OnClick(object sender, RoutedEventArgs e)
     {
         _display.CopyCurrentModule();
+    }
+
+    /// <summary>
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void CloneMenuItem_OnClick(object sender, RoutedEventArgs e)
+    {
+        _display.CloneCurrentModule();
     }
 
     /// <summary>


### PR DESCRIPTION
This PR implements a context menu item and keyboard shortcut (ctrl+shift+c) that will clone a module if it is in a module collection.

ON an error a message box will be displayed.

The feature is backed using the previously implemented copy and paste commands.