### PR TITLE
Add more debugging information during calibration

### DIFF
--- a/Code/TMG.Estimation/Calibration/ScalarTarget.cs
+++ b/Code/TMG.Estimation/Calibration/ScalarTarget.cs
@@ -70,7 +70,7 @@ public sealed class ScalarTarget : CalibrationTarget
         // TODO: We might want to add some momentum to avoid getting stuck
         if (MathF.Abs(derivative) < MinimumAbsoluteDerivative)
         {
-            Console.WriteLine($"{Name} encountered a derivative that was under the minimum allowed {MinimumAbsoluteDerivative}, no parameter change has been applied.");
+            Console.WriteLine($"{Name} encountered a derivative that was under the minimum allowed {MinimumAbsoluteDerivative}, no parameter change has been applied. Target = {_targetValue}, BeforeStep = {_baseValue}, AfterStep = {_stepValue}.");
             return currentValue;
         }
 


### PR DESCRIPTION
This PR adds the target value, the initial modelled value, and the step value when using a scalar calibration target.
