### PR TITLE
Added Multiplier for Probability Targets' Change

### DIFF
--- a/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
+++ b/Code/TMG.Estimation/Calibration/ProbabilityMatrixTarget.cs
@@ -43,6 +43,9 @@ public sealed class ProbabilityMatrixTarget : CalibrationTarget
     [RunParameter("Maximum Value", float.PositiveInfinity, "The highest value allowed for this parameter.")]
     public float MaximumValue;
 
+    [RunParameter("Change Weight", 1.0f, "A multiplier for the amount of change to apply.  Lower this if there are multiple targets targeting a similar system to set priorities.")]
+    public float ChangeWeight;
+
     [SubModelInformation(Required = true, Description = "The total matrix from the observed.")]
     public IDataSource<SparseTwinIndex<float>> ObservedTotal;
 
@@ -99,7 +102,7 @@ public sealed class ProbabilityMatrixTarget : CalibrationTarget
         {
             var delta = ratio;
 
-            return ClampValue(currentValue * delta, MinimumValue, MaximumValue);
+            return ClampValue(currentValue * (delta * ChangeWeight), MinimumValue, MaximumValue);
         }
         else
         {
@@ -109,7 +112,7 @@ public sealed class ProbabilityMatrixTarget : CalibrationTarget
                 Console.WriteLine($"We found an invalid step size for {Name}, TargetProbability {_targetProbability}, Current {_baseRunProbability}, Delta {delta}!");
                 return currentValue;
             }
-            return ClampValue(currentValue + delta, MinimumValue, MaximumValue);
+            return ClampValue(currentValue + (delta * ChangeWeight), MinimumValue, MaximumValue);
         }
     }
 

--- a/Code/TMG.Estimation/Calibration/ProbabilityTarget.cs
+++ b/Code/TMG.Estimation/Calibration/ProbabilityTarget.cs
@@ -34,6 +34,9 @@ public sealed class ProbabilityTarget : CalibrationTarget
     [RunParameter("Maximum Value", float.PositiveInfinity, "The highest value allowed for this parameter.")]
     public float MaximumValue;
 
+    [RunParameter("Change Weight", 1.0f, "A multiplier for the amount of change to apply.  Lower this if there are multiple targets targeting a similar system to set priorities.")]
+    public float ChangeWeight;
+
     private float _targetProbability;
 
     private float _baseRunProbability;
@@ -58,7 +61,7 @@ public sealed class ProbabilityTarget : CalibrationTarget
             Console.WriteLine($"We found an invalid step size for {Name}!");
             return currentValue;
         }
-        var next = ClampValue(currentValue + delta, MinimumValue, MaximumValue);
+        var next = ClampValue(currentValue + (delta * ChangeWeight), MinimumValue, MaximumValue);
         return next;
     }
 


### PR DESCRIPTION
Adds a new parameter "Change Weight" for both ProbabilityTarget and ProbabilityMatrixTarget to help control how much the parameter gets modified after each iteration of calibration.  The weight gets multiplied by the delta before clamping so we'll still never accidently go outside of the bounds.  The reason you might want to use this is if there are multiple parameters that get combined at different spatial levels.  With this you could reduce a global parameter's change while keeping a more targeted spatial parameter at a full value, while avoiding some of the divergent behavior that could arise previously.