### PR TITLE
Allow modifying and running Previous Runs.

### DIFF
--- a/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
+++ b/Code/XTMF.Gui/UserControls/ModelSystemDisplay/ModelSystemDisplay.xaml.cs
@@ -231,7 +231,7 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
         {
             if (_canSaveModelSystem != value)
             {
-                _canSaveModelSystem = value;
+                _canSaveModelSystem = value && !_session.IsReadOnly;
                 OnPropertyChanged(nameof(CanSaveModelSystem));
             }
         }
@@ -1174,14 +1174,21 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
             {
                 if (Session.SaveWait())
                 {
+                    bool success = true;
                     try
                     {
                         if (!Session.Save(ref error))
                         {
                             Dispatcher.Invoke(() =>
                             {
-                                MessageBox.Show(MainWindow.Us, "Failed to save.\r\n" + error, "Unable to Save",
-                                    MessageBoxButton.OK, MessageBoxImage.Error);
+                                success = false;
+                                StatusSnackBar.MessageQueue.Enqueue($"Failed to Save \r\n{error}");
+                                SaveModelSystemButton.Background = Brushes.Transparent;
+                                SaveModelSystemButton.BorderBrush = Brushes.Transparent;
+                                ButtonProgressAssist.SetIsIndicatorVisible(SaveModelSystemButton, false);
+                                ButtonProgressAssist.SetIsIndeterminate(SaveModelSystemButton, false);
+                                ButtonProgressAssist.SetIndicatorBackground(SaveModelSystemButton, Brushes.Transparent);
+                                ButtonProgressAssist.SetIndicatorForeground(SaveModelSystemButton, Brushes.Transparent);
                             });
                         }
                     }
@@ -1195,19 +1202,21 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
                     }
                     finally
                     {
-                        CanSaveModelSystem = false;
                         Session.SaveRelease();
-
-                        Dispatcher.Invoke(() =>
+                        if (success)
                         {
-                            StatusSnackBar.MessageQueue.Enqueue("Model system finished saving");
-                            SaveModelSystemButton.Background = Brushes.Transparent;
-                            SaveModelSystemButton.BorderBrush = Brushes.Transparent;
-                            ButtonProgressAssist.SetIsIndicatorVisible(SaveModelSystemButton, false);
-                            ButtonProgressAssist.SetIsIndeterminate(SaveModelSystemButton, false);
-                            ButtonProgressAssist.SetIndicatorBackground(SaveModelSystemButton, Brushes.Transparent);
-                            ButtonProgressAssist.SetIndicatorForeground(SaveModelSystemButton, Brushes.Transparent);
-                        });
+                            CanSaveModelSystem = false;
+                            Dispatcher.Invoke(() =>
+                            {
+                                StatusSnackBar.MessageQueue.Enqueue("Model system finished saving");
+                                SaveModelSystemButton.Background = Brushes.Transparent;
+                                SaveModelSystemButton.BorderBrush = Brushes.Transparent;
+                                ButtonProgressAssist.SetIsIndicatorVisible(SaveModelSystemButton, false);
+                                ButtonProgressAssist.SetIsIndeterminate(SaveModelSystemButton, false);
+                                ButtonProgressAssist.SetIndicatorBackground(SaveModelSystemButton, Brushes.Transparent);
+                                ButtonProgressAssist.SetIndicatorForeground(SaveModelSystemButton, Brushes.Transparent);
+                            });
+                        }
                     }
                 }
             });
@@ -1697,9 +1706,9 @@ public partial class ModelSystemDisplay : UserControl, ITabCloseListener, INotif
         StringBuilder sb = new();
         var display = GetCurrentParameterDisplay();
         sb.AppendLine("Name\tValue\tDescription");
-        foreach(var item in display.Items)
+        foreach (var item in display.Items)
         {
-            if(item is ParameterDisplayModel parameter)
+            if (item is ParameterDisplayModel parameter)
             {
                 sb.Append(parameter.Name);
                 sb.Append('\t');

--- a/Code/XTMF.Run/Program.cs
+++ b/Code/XTMF.Run/Program.cs
@@ -90,7 +90,7 @@ class Program
         using var messagesToSend = new BlockingCollection<byte[]>();
         XTMFRuntime runtime = null;
         // create the client
-        Task.Factory.StartNew(() =>
+        var toHostCommunication = Task.Factory.StartNew(() =>
         {
             var reader = new BinaryReader(clientStream, Encoding.Unicode, true);
             Configuration config = new(reader.ReadString())
@@ -130,7 +130,7 @@ class Program
             runtime = new XTMFRuntime(config);
             try
             {
-                while (true)
+                while (!messagesToSend.IsCompleted)
                 {
                     switch ((ToClient)reader.ReadInt32())
                     {
@@ -149,26 +149,55 @@ class Program
                         case ToClient.CancelModelRun:
                             CancelModelSystem(root);
                             Console.WriteLine("Model System cancelled by host.");
-                            return;
+                            messagesToSend.CompleteAdding();
+                            continue;
                         case ToClient.KillModelRun:
                             Console.WriteLine("Model system termination signalled.");
-                            return;
+                            messagesToSend.CompleteAdding();
+                            continue;
                         default:
                             Console.WriteLine("Unknown command!");
-                            return;
+                            messagesToSend.CompleteAdding();
+                            continue;
+                    }
+                }
+            }
+            catch
+            {
+                // drain the pipe of writes
+                messagesToSend?.CompleteAdding();
+                // drain the pipe of host writes
+                while(true)
+                {
+                    try
+                    {
+                        reader.ReadInt32();
+                    }
+                    catch
+                    {
+                        break;
                     }
                 }
             }
             finally
             {
+                // If the connection fails notify that we have processed the last message.
                 messagesToSend?.CompleteAdding();
-                Environment.Exit(0);
             }
+
         }, TaskCreationOptions.LongRunning);
-        // Send out the messages as they arise
-        foreach (var msg in messagesToSend.GetConsumingEnumerable())
+        try
         {
-            clientStream.Write(msg, 0, msg.Length);
+            // Send out the messages as they arise
+            foreach (var msg in messagesToSend.GetConsumingEnumerable())
+            {
+                clientStream.Write(msg, 0, msg.Length);
+            }
+            clientStream.Dispose();
+        }
+        finally
+        {
+            Environment.Exit(0);
         }
     }
 
@@ -229,23 +258,32 @@ class Program
                     // Make sure everything is synchronized
                     writer.BaseStream.Flush();
                     writer.Flush();
-                    // Write out the linked paramters
+                    // Write out the linked parameters
                     var lps = run.LinkedParameters;
-                    writer.Write(lps.Count);
-                    StringBuilder sb = new();
-                    foreach (var lp in lps)
+                    // If there are no linked parameters then write out a 0
+                    if (lps is null)
                     {
-                        writer.Write(lp.Name);
-                        writer.Write(lp.Value);
-                        var references = lp.Parameters;
-                        writer.Write(references.Count);
-                        foreach (var reference in references)
-                        {
-                            var name = Project.LookupName(reference, root.RealModelSystemStructure);
-                            writer.Write(name);
-                        }
+                        writer.Write(0);
+                        writer.Flush();
                     }
-                    writer.Flush();
+                    else
+                    {
+                        writer.Write(lps.Count);
+                        StringBuilder sb = new();
+                        foreach (var lp in lps)
+                        {
+                            writer.Write(lp.Name);
+                            writer.Write(lp.Value);
+                            var references = lp.Parameters;
+                            writer.Write(references.Count);
+                            foreach (var reference in references)
+                            {
+                                var name = Project.LookupName(reference, root.RealModelSystemStructure);
+                                writer.Write(name);
+                            }
+                        }
+                        writer.Flush();
+                    }
                 });
             };
             run.RunCompleted += () =>

--- a/Code/XTMF.Run/Program.cs
+++ b/Code/XTMF.Run/Program.cs
@@ -164,7 +164,6 @@ class Program
             }
             catch
             {
-                // drain the pipe of writes
                 messagesToSend?.CompleteAdding();
                 // drain the pipe of host writes
                 while(true)

--- a/Code/XTMF/Editing/ModelSystemEditingSession.cs
+++ b/Code/XTMF/Editing/ModelSystemEditingSession.cs
@@ -341,8 +341,8 @@ public sealed class ModelSystemEditingSession : IDisposable
                         [],
                          ModelSystemModel.Description
                         );
-                    if (true)
-                    //if (((Configuration)Configuration).RemoteHost)
+                    
+                    if (((Configuration)Configuration).RemoteHost)
                     {
                         run = XTMFRun.CreateRemoteHost(cloneProject, _ModelSystemIndex, ModelSystemModel,
                             Runtime.Configuration, runName, overwrite);

--- a/Code/XTMF/Editing/ModelSystemEditingSession.cs
+++ b/Code/XTMF/Editing/ModelSystemEditingSession.cs
@@ -68,7 +68,7 @@ public sealed class ModelSystemEditingSession : IDisposable
         }
         return [];
     }
-    
+
     public Task<List<string>> GetPreviousRunNamesAsync()
     {
         return new Task<List<string>>(GetPreviousRunNames);
@@ -115,11 +115,13 @@ public sealed class ModelSystemEditingSession : IDisposable
     /// <param name="runtime">A link to the XTMFRuntime</param>
     /// <param name="projectSession">The project this is for.</param>
     /// <param name="runFile">The location of the previous run.</param>
-    public ModelSystemEditingSession(XTMFRuntime runtime, ProjectEditingSession projectSession, string runFile)
+    public ModelSystemEditingSession(XTMFRuntime runtime, ProjectEditingSession projectSession, string runFile, bool isPreviousRun)
     {
         Runtime = runtime;
         ProjectEditingSession = projectSession;
         _ModelSystemIndex = -1;
+        _saveSemaphor = new Semaphore(1, 1);
+        _isPreviousRun = isPreviousRun;
         ModelSystemModel = new ModelSystemModel(Runtime, this, projectSession.Project, runFile);
     }
 
@@ -143,6 +145,16 @@ public sealed class ModelSystemEditingSession : IDisposable
     /// </summary>
     /// <returns>If it is not a project, true.</returns>
     public bool EditingModelSystem => _ModelSystem != null;
+
+    /// <summary>
+    /// Is the session read only?
+    /// </summary>
+    public bool IsReadOnly => _isPreviousRun;
+
+    /// <summary>
+    /// Set to true if the model system is a previous run.
+    /// </summary>
+    private bool _isPreviousRun = false;
 
     /// <summary>
     ///     The model system's model that we will interact with.
@@ -329,7 +341,8 @@ public sealed class ModelSystemEditingSession : IDisposable
                         [],
                          ModelSystemModel.Description
                         );
-                    if (((Configuration)Configuration).RemoteHost)
+                    if (true)
+                    //if (((Configuration)Configuration).RemoteHost)
                     {
                         run = XTMFRun.CreateRemoteHost(cloneProject, _ModelSystemIndex, ModelSystemModel,
                             Runtime.Configuration, runName, overwrite);
@@ -355,7 +368,7 @@ public sealed class ModelSystemEditingSession : IDisposable
                 }
                 else
                 {
-                    run = XTMFRun.CreateLocalRun(ProjectEditingSession.Project, ModelSystemModel,
+                    run = XTMFRun.CreateRemoteHost(ProjectEditingSession.Project, ModelSystemModel,
                         Runtime.Configuration, runName, overwrite);
                 }
                 return run;
@@ -380,7 +393,7 @@ public sealed class ModelSystemEditingSession : IDisposable
     /// <param name="newQueueIndex"></param>
     public void ReorderQueuedRun(XTMFRun run, int newQueueIndex)
     {
-        Runtime.RunController.ReorderQueuedRun(run,newQueueIndex);
+        Runtime.RunController.ReorderQueuedRun(run, newQueueIndex);
     }
 
     /// <summary>
@@ -432,6 +445,11 @@ public sealed class ModelSystemEditingSession : IDisposable
     /// <returns>If we were able to save or not.</returns>
     public bool Save(ref string error)
     {
+        if (IsReadOnly)
+        {
+            error = "Cannot save a previous run.";
+            return false;
+        }
         lock (_SessionLock)
         {
             if (!ModelSystemModel.Save(ref error))
@@ -758,7 +776,7 @@ public sealed class ModelSystemEditingSession : IDisposable
     public bool IsSaving()
     {
         var gotLock = _saveSemaphor.WaitOne(0, false);
-        if(gotLock)
+        if (gotLock)
         {
             _saveSemaphor.Release();
             return false;

--- a/Code/XTMF/Editing/ProjectEditingSession.cs
+++ b/Code/XTMF/Editing/ProjectEditingSession.cs
@@ -557,7 +557,7 @@ public sealed class ProjectEditingSession : IDisposable
         }
         try
         {
-            session = new ModelSystemEditingSession(_Runtime, this, runFileName);
+            session = new ModelSystemEditingSession(_Runtime, this, runFileName, true);
             return true;
         }
         catch (Exception e)

--- a/Code/XTMF/Run/XTMFRunRemoteHost.cs
+++ b/Code/XTMF/Run/XTMFRunRemoteHost.cs
@@ -17,6 +17,7 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -113,10 +114,11 @@ sealed class XTMFRunRemoteHost : XTMFRun
     {
         lock (this)
         {
-            BinaryWriter writer = new(_Pipe, System.Text.Encoding.Unicode, true);
             try
             {
-                writer.Write((Int32)signal);
+                Span<byte> buffer = stackalloc byte[sizeof(int)];
+                BinaryPrimitives.WriteInt32LittleEndian(buffer, (int)signal);
+                _Pipe.Write(buffer);
             }
             catch (Exception e)
             {
@@ -274,13 +276,14 @@ sealed class XTMFRunRemoteHost : XTMFRun
     {
         try
         {
-            var length = (int)reader.ReadInt64();
-            byte[] msText = new byte[length];
-            var soFar = 0;
-            while (soFar < length)
+            var llength = reader.ReadInt64();
+            if(llength > int.MaxValue)
             {
-                soFar += reader.Read(msText, soFar, length - soFar);
+                throw new Exception("The model system is too large to load!");
             }
+            var length = (int)llength;
+            byte[] msText = new byte[(int)length];
+            reader.BaseStream.ReadExactly(msText, 0, length);
             using var stream = new MemoryStream(msText);
             var mss = ModelSystemStructure.Load(stream, Configuration);
             var numberOfLinkedParameters = reader.ReadInt32();
@@ -291,7 +294,6 @@ sealed class XTMFRunRemoteHost : XTMFRun
                 var lp = new LinkedParameter(name);
                 string error = null;
                 lp.SetValue(reader.ReadString(), ref error);
-
                 int numberOfReferences = reader.ReadInt32();
                 for (int j = 0; j < numberOfReferences; j++)
                 {

--- a/Code/XTMF/XTMFRun.cs
+++ b/Code/XTMF/XTMFRun.cs
@@ -120,15 +120,25 @@ public abstract class XTMFRun : IDisposable
             overwrite);
     }
 
+    /// <summary>
+    /// Create a new run on a remote host
+    /// 
+    /// Call this when you want to re-run a previously executed run.
+    /// </summary>
+    /// <param name="project">The project associated with the run.</param>
+    /// <param name="model">The model system model to use for the run.</param>
+    /// <param name="configuration">The configuration settings for the run.</param>
+    /// <param name="runName">The name of the run.</param>
+    /// <param name="overwrite">Whether to overwrite existing run data.</param>
+    /// <returns>A new instance of <see cref="XTMFRun"/> configured for remote execution.</returns>
+    public static XTMFRun CreateRemoteHost(Project project, ModelSystemModel model, Configuration configuration, string runName, bool overwrite = false)
+    {
+        return new XTMFRunRemoteHost(configuration, model.Root, model.LinkedParameters.GetRealLinkedParameters(), runName, Path.Combine(configuration.ProjectDirectory, project.Name, runName), overwrite);
+    }
+
     public static XTMFRun CreateLocalRun(Project project, ModelSystemModel model, Configuration configuration, string runName, bool overwrite = false)
     {
         return new XTMFRunLocal(project, model, configuration, runName, overwrite);
-    }
-
-    public static XTMFRun CreateRemoteHost(Project project, ModelSystemStructureModel root, Configuration config, string runName, bool overwrite = false)
-    {
-        return new XTMFRunRemoteHost(config, root, [], runName, Path.Combine(config.ProjectDirectory, project.Name, runName),
-            overwrite);
     }
 
     public static XTMFRun CreateRemoteClient(Configuration configuration, string runName, string runDirectory, string modelSystem)


### PR DESCRIPTION
This commit also gives better feedback when trying to save to a previous run, which is not allowed.
In the future we might want to instead prompt for a new name to save the current model system display to.
