### PR TITLE
Add Custom Attributes When Loading Households

### DIFF
--- a/TorontoHouseholds/CustomDataColumn.cs
+++ b/TorontoHouseholds/CustomDataColumn.cs
@@ -38,6 +38,11 @@ public sealed class CustomDataColumn : IModule
 
     public bool RuntimeValidation(ref string error)
     {
+        if(ColumnIndex < 0)
+        {
+            error = "Column Index must be greater than or equal to 0.";
+            return false;
+        }
         return true;
     }
 }

--- a/TorontoHouseholds/CustomDataColumn.cs
+++ b/TorontoHouseholds/CustomDataColumn.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Copyright 2025 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
 using XTMF;
 
 namespace TMG.Tasha;

--- a/TorontoHouseholds/CustomDataColumn.cs
+++ b/TorontoHouseholds/CustomDataColumn.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using XTMF;
+
+namespace TMG.Tasha;
+
+[ModuleInformation(Description = "Used for specifying extra attributes for different data types.  Values must be floating point.")]
+public sealed class CustomDataColumn : IModule
+{
+    [RunParameter("Variable Name", "", "The name of the variable to assign to.")]
+    public string VariableName;
+
+    [RunParameter("Column Index", -1, "The 0 indexed column to read from.")]
+    public int ColumnIndex;
+
+    public string Name { get; set; } = string.Empty;
+
+    public float Progress => 0f;
+
+    public Tuple<byte, byte, byte> ProgressColour => new (50, 150, 50);
+
+    public bool RuntimeValidation(ref string error)
+    {
+        return true;
+    }
+}

--- a/TorontoHouseholds/HouseholdLoader.cs
+++ b/TorontoHouseholds/HouseholdLoader.cs
@@ -112,6 +112,9 @@ public sealed class HouseholdLoader : IDataLoader<ITashaHousehold>, IDisposable
     [SubModelInformation(Required = false, Description = "An alternative way of specifying the household file location.")]
     public FileLocation HouseholdFile;
 
+    [SubModelInformation(Required = false, Description = "Extra attributes to load for each household.")]
+    public CustomDataColumn[] CustomDataColumns;
+
     private bool AllDataLoaded = true;
     private IVehicleType AutoType;
     private ITashaHousehold[] Households;
@@ -675,6 +678,12 @@ public sealed class HouseholdLoader : IDataLoader<ITashaHousehold>, IDisposable
             h.ExpansionFactor = tempFloat;
             Reader.Get(out int dwellingType, DwellingTypeCol);
             h.DwellingType = (DwellingType)dwellingType;
+
+            foreach(var column in CustomDataColumns)
+            {
+                Reader.Get(out float value, column.ColumnIndex);
+                h.Attach(column.VariableName, value);
+            }
 
             void AssignNumberOfVehicles(Household household, int numberOfAutos, int numberOfSecondaryVehicles)
             {

--- a/TorontoHouseholds/PersonLoader.cs
+++ b/TorontoHouseholds/PersonLoader.cs
@@ -95,6 +95,9 @@ public class PersonLoader : IDatachainLoader<ITashaHousehold, ITashaPerson>, IDi
     [SubModelInformation(Required = false, Description = "An alternative way of specifying the person file location.")]
     public FileLocation PersonFile;
 
+    [SubModelInformation(Required = false, Description = "Extra attributes to load for each person.")]
+    public CustomDataColumn[] CustomDataColumns;
+
     private bool ContainsData;
 
     private CsvReader Reader;
@@ -296,6 +299,11 @@ public class PersonLoader : IDatachainLoader<ITashaHousehold, ITashaPerson>, IDi
             {
                 Reader.Get(out tempChar, PersonDriversLicenceCol);
                 p.Licence = (tempChar == 'Y');
+            }
+            foreach (var column in CustomDataColumns)
+            {
+                Reader.Get(out float tempFloat, column.ColumnIndex);
+                p.Attach(column.VariableName, tempFloat);
             }
             persons.Add(p);
             if(Reader.LoadLine() == 0)

--- a/TorontoHouseholds/TripChainLoader.cs
+++ b/TorontoHouseholds/TripChainLoader.cs
@@ -85,6 +85,9 @@ public class TripChainLoader : IDatachainLoader<ITashaPerson, ITripChain>, IDisp
     [RunParameter("Auto Fix Activity Episodes", true, "Automatically make changes to the given activity episodes.")]
     public bool AutoFixActivityEpisodes;
 
+    [SubModelInformation(Required = false, Description = "Extra attributes to load for each trip.")]
+    public CustomDataColumn[] CustomDataColumns;
+
     [RootModule]
     public ITashaRuntime TashaRuntime;
 
@@ -226,6 +229,11 @@ public class TripChainLoader : IDatachainLoader<ITashaPerson, ITripChain>, IDisp
                         }
                     }
                 }
+            }
+            foreach (var column in CustomDataColumns)
+            {
+                Reader.Get(out tempFloat, column.ColumnIndex);
+                t.Attach(column.VariableName, tempFloat);
             }
             //if (lastChain != (chain = int.Parse(parts[TripChainNumber])))
             if ( currentChain == null 


### PR DESCRIPTION
This patch adds the ability to attached custom data to households, persons, and trips as they are being loaded.
