### PR TITLE
Allow Custom Columns to have data other than floats

### DIFF
--- a/TorontoHouseholds/CustomDataColumn.cs
+++ b/TorontoHouseholds/CustomDataColumn.cs
@@ -16,7 +16,9 @@
     You should have received a copy of the GNU General Public License
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
+using Datastructure;
 using System;
+using Tasha.Common;
 using XTMF;
 
 namespace TMG.Tasha;
@@ -30,11 +32,57 @@ public sealed class CustomDataColumn : IModule
     [RunParameter("Column Index", -1, "The 0 indexed column to read from.")]
     public int ColumnIndex;
 
+    public enum DataType
+    {
+        Float = 0,
+        String = 1,
+        Character = 2,
+        Integer = 3,
+    }
+
+    [RunParameter("Data Type", DataType.Float, "The type of data to read in.")]
+    public DataType ColumnDataType = DataType.Float;
+
+    public void ReadIntoAttachable(IAttachable attachable, CsvReader reader)
+    {
+        switch(ColumnDataType)
+        {
+            case DataType.Float:
+                {
+                    reader.Get(out float temp, ColumnIndex);
+                    attachable.Attach(VariableName, temp);
+                }
+                break;
+            case DataType.String:
+                {
+                    reader.Get(out string temp, ColumnIndex);
+                    attachable.Attach(VariableName, temp);
+                }
+                break;
+            case DataType.Character:
+                {
+                    reader.Get(out char temp, ColumnIndex);
+                    attachable.Attach(VariableName, temp);
+                }
+                break;
+            case DataType.Integer:
+                {
+                    reader.Get(out int temp, ColumnIndex);
+                    attachable.Attach(VariableName, temp);
+                }
+                break;
+            default:
+                throw new XTMFRuntimeException(this, "Unrecognized DataType.");
+        }
+    }
+
     public string Name { get; set; } = string.Empty;
 
     public float Progress => 0f;
 
     public Tuple<byte, byte, byte> ProgressColour => new (50, 150, 50);
+
+
 
     public bool RuntimeValidation(ref string error)
     {

--- a/TorontoHouseholds/HouseholdLoader.cs
+++ b/TorontoHouseholds/HouseholdLoader.cs
@@ -679,10 +679,9 @@ public sealed class HouseholdLoader : IDataLoader<ITashaHousehold>, IDisposable
             Reader.Get(out int dwellingType, DwellingTypeCol);
             h.DwellingType = (DwellingType)dwellingType;
 
-            foreach(var column in CustomDataColumns)
+            foreach (var column in CustomDataColumns)
             {
-                Reader.Get(out float value, column.ColumnIndex);
-                h.Attach(column.VariableName, value);
+                column.ReadIntoAttachable(h, Reader);
             }
 
             void AssignNumberOfVehicles(Household household, int numberOfAutos, int numberOfSecondaryVehicles)

--- a/TorontoHouseholds/PersonLoader.cs
+++ b/TorontoHouseholds/PersonLoader.cs
@@ -302,8 +302,7 @@ public class PersonLoader : IDatachainLoader<ITashaHousehold, ITashaPerson>, IDi
             }
             foreach (var column in CustomDataColumns)
             {
-                Reader.Get(out float tempFloat, column.ColumnIndex);
-                p.Attach(column.VariableName, tempFloat);
+                column.ReadIntoAttachable(p, Reader);
             }
             persons.Add(p);
             if(Reader.LoadLine() == 0)

--- a/TorontoHouseholds/TripChainLoader.cs
+++ b/TorontoHouseholds/TripChainLoader.cs
@@ -232,8 +232,7 @@ public class TripChainLoader : IDatachainLoader<ITashaPerson, ITripChain>, IDisp
             }
             foreach (var column in CustomDataColumns)
             {
-                Reader.Get(out tempFloat, column.ColumnIndex);
-                t.Attach(column.VariableName, tempFloat);
+                column.ReadIntoAttachable(t, Reader);
             }
             //if (lastChain != (chain = int.Parse(parts[TripChainNumber])))
             if ( currentChain == null 


### PR DESCRIPTION
This commit expands the capabilities of the CustomDataColumn class to read in strings, characters, and integers in addition
to the currently implemented floating point numbers.
