### PR TITLE
Fix reflecting on unloaded model systems

### DIFF
--- a/Code/TMG.Functions/ModelSystemReflection.cs
+++ b/Code/TMG.Functions/ModelSystemReflection.cs
@@ -299,6 +299,11 @@ public static class ModelSystemReflection
     {
         foreach (var ms in project.ModelSystemStructure)
         {
+            // SKip model systems that are not loaded.
+            if(ms is null)
+            {
+                continue;
+            }
             if (FindModuleStructure(ms, toFind, ref modelSystemStructure))
             {
                 return true;


### PR DESCRIPTION
Currently if you are running XTMF with a debugger you can end up in cases where the configuration will have projects
with additional model systems stored in the project but there is no module loaded for that model system.  With
delayed loading that will be filled with a null and crash the model run.  This patch insteads has the reflection
skip over model systems that are not loaded.
