### PR TITLE
Update modeller bridge to be more resilient in the case a tool is not found.

### DIFF
--- a/Code/TMG.Emme/ModellerBridge.py
+++ b/Code/TMG.Emme/ModellerBridge.py
@@ -485,8 +485,6 @@ class XTMFBridge:
         try:
             #figure out how long the macro's name is
             macroName = self.ReadString()
-            if not self.EnsureModellerToolExists(macroName):
-                return
 
             # Read in the parameters from XTMF (This needs to happen first so we don't get out of sync).
             if useBinaryParameters:
@@ -496,7 +494,11 @@ class XTMFBridge:
                 parameterList = [self.ReadString() for p in range(0, numberOfParameters)]
             else:
                 parameterString = self.ReadString()
-                
+
+            # Do the check here instead of right when we got the macroName to make sure that XTMF has
+            # finished writing all of its data to the stream.
+            if not self.EnsureModellerToolExists(macroName):
+                return              
             
             # Now we can create the tool
             tool = self.CreateTool(macroName)

--- a/Code/TMG.Emme/ModellerControllerParameter.cs
+++ b/Code/TMG.Emme/ModellerControllerParameter.cs
@@ -21,8 +21,8 @@ namespace TMG.Emme;
 
 public class ModellerControllerParameter
 {
-    internal string Name;
-    internal string Value;
+    public readonly string Name;
+    public readonly string Value;
 
     public ModellerControllerParameter(string name, string value)
     {

--- a/Code/Tasha.Validation/PerformanceMeasures/RidershipCounts.cs
+++ b/Code/Tasha.Validation/PerformanceMeasures/RidershipCounts.cs
@@ -27,6 +27,7 @@ using XTMF;
 
 namespace Tasha.Validation.PerformanceMeasures;
 
+[ModuleInformation(Description = "This module gets the number of riders that board at least one time for each of the operators that we want to consider.")]
 public class RidershipCounts : IEmmeTool
 {
     private const string ToolName = "tmg.analysis.transit.strategy_analysis.volume_per_operator";


### PR DESCRIPTION
If a tool is not found the modeller bridge will not finish reading in all of the parameters from the C# side of the bridge, leading to invalid codes being sent through the bridge.  This patch makes sure to flush all of that content before doing the check and potentially sending the error.
