### PR TITLE
Fix Ctrl+W for HelpDialog

### DIFF
--- a/Code/XTMF.Gui/UserControls/Help/HelpDialog.xaml
+++ b/Code/XTMF.Gui/UserControls/Help/HelpDialog.xaml
@@ -25,7 +25,7 @@
              xmlns:userControls="clr-namespace:XTMF.Gui.UserControls"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"  HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
-             d:DesignHeight="300" d:DesignWidth="600">
+             d:DesignHeight="300" d:DesignWidth="600" Focusable="True">
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource MaterialDesignPaper}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition  MinWidth="150" Width="*" />


### PR DESCRIPTION
Currently if you do not mouse click on the help window the keyboard shortcut ctrl+w doesn't
work.  With this patch, after hitting F1 on a model system you can immediately press
ctrl+w to close the help.
