### PR TITLE
Stop ensuring a directory exists when routing a project save.

### DIFF
--- a/Code/XTMF/Project.cs
+++ b/Code/XTMF/Project.cs
@@ -257,10 +257,6 @@ public sealed partial class Project : IProject
         bool ret;
         try
         {
-            if (!Directory.Exists(dirName))
-            {
-                Directory.CreateDirectory(dirName);
-            }
             if (((Configuration)_Configuration).DivertSaveRequests)
             {
                 ret = true;
@@ -268,7 +264,10 @@ public sealed partial class Project : IProject
             }
             else
             {
-
+                if (!Directory.Exists(dirName))
+                {
+                    Directory.CreateDirectory(dirName);
+                }
                 ret = Save(Path.Combine(dirName, "Project.xml"), ref error);
                 if (_ClonedFrom != null)
                 {


### PR DESCRIPTION
In the current implemention, regardless if a save is going to be routed, a directory would be created.  This change will
affect model systems that do estimation and calibration, now no longer creating extra folders in the root project directory.
