### PR TITLE
Fix the exclude module list

### DIFF
--- a/Code/XTMF.Gui/App.xaml.cs
+++ b/Code/XTMF.Gui/App.xaml.cs
@@ -76,8 +76,11 @@ public partial class App : Application
                 TransitionAssist.SetDisableTransitions(Gui.MainWindow.Us, EditorController.Runtime.Configuration.IsDisableTransitionAnimations);
                 xtmfMainWindow.UpdateRecentProjectsMenu();
                 xtmfMainWindow.Show();
-                Task.Run(() =>
+                if (!EditorController.Runtime.Configuration.ModulesLoaded)
                 {
+                    Task.Run(() =>
+                    {
+
                     EditorController.Runtime.Configuration.LoadModules(() =>
                     {
                         Dispatcher.BeginInvoke(new Action(() =>
@@ -86,7 +89,16 @@ public partial class App : Application
                             xtmfMainWindow.StatusDisplay.Text = "Ready";
                         }));
                     });
-                });
+                    });
+                }
+                else
+                {
+                    Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        xtmfMainWindow.IsEnabled = true;
+                        xtmfMainWindow.StatusDisplay.Text = "Ready";
+                    }));
+                }
             }));
         }, false);
        

--- a/Code/XTMF/Configuration.cs
+++ b/Code/XTMF/Configuration.cs
@@ -218,6 +218,8 @@ public sealed class Configuration : IConfiguration, IDisposable, INotifyProperty
     public bool DivertSaveRequests { get; set; } = false;
     public bool IsLocalConfiguration => Path.GetFileName(ConfigurationFileName) == "LocalXTMFConfiguration.xml";
 
+    public bool ModulesLoaded { get; set; }
+
     public void CreateProgressReport(string name, Func<float> ReportProgress, Tuple<byte, byte, byte> c = null)
     {
         lock (this)
@@ -962,7 +964,6 @@ public sealed class Configuration : IConfiguration, IDisposable, INotifyProperty
 
     private void LoadModules()
     {
-
         // load in the types from system
         LoadAssembly(typeof(float).GetType().Assembly);
         // Load the given base assembly
@@ -983,9 +984,9 @@ public sealed class Configuration : IConfiguration, IDisposable, INotifyProperty
         {
             var files = Directory.GetFiles(_ModuleDirectory, "*.dll");
             var excludedDlls = LoadExcludeList();
-            //Parallel.For(0, files.Length,
-            //(int i) =>
-            for (int i = 0; i < files.Length; i++)
+            Parallel.For(0, files.Length,
+            (int i) =>
+            //for (int i = 0; i < files.Length; i++)
             {
                 try
                 {
@@ -993,7 +994,7 @@ public sealed class Configuration : IConfiguration, IDisposable, INotifyProperty
                     
 
                     var name = Path.GetFileName(fileName);
-                    if (!excludedDlls.Contains(name))
+                    if (!excludedDlls.Contains(name, StringComparer.OrdinalIgnoreCase))
                     {
                         var fullPath = Path.GetFullPath(files[i]);
                         LoadAssembly(Assembly.LoadFrom(fullPath));
@@ -1004,8 +1005,9 @@ public sealed class Configuration : IConfiguration, IDisposable, INotifyProperty
                     Console.WriteLine("Error when trying to load assembly '" + Path.GetFileNameWithoutExtension(files[i]) + "'");
                     Console.WriteLine(e.Message);
                 }
-            }//);
+            });
         }
+        ModulesLoaded = true;
     }
 
     private List<string> LoadExcludeList()

--- a/Code/XTMFTesting/TMG/Data/TestCompiler.cs
+++ b/Code/XTMFTesting/TMG/Data/TestCompiler.cs
@@ -250,6 +250,17 @@ public class TestCompiler
     }
 
     [TestMethod]
+    public void TestMultipleDivisions()
+    {
+        CompareScalar("A / B / C",
+        [
+            CreateScalarData("A", 1),
+            CreateScalarData("B", 2),
+            CreateScalarData("C", 3)
+        ], 0.16666667f);
+    }
+
+    [TestMethod]
     public void TestSubtractLHSVectorRHSMatrixHorizontal()
     {
         CompareMatrix("AsHorizontal(A) - B",


### PR DESCRIPTION
In the current implementation the Modules/Exclude.txt file would only work if the
excluded dll only had lower case letter.  The new implementation makes it case
insensitive.

Additionally we now only load the modules once when starting up the GUI.
