### PR TITLE
Remove Root Condition for VKTCalc

### DIFF
--- a/Code/Tasha.Validation/PerformanceMeasures/VKTCalc.cs
+++ b/Code/Tasha.Validation/PerformanceMeasures/VKTCalc.cs
@@ -29,8 +29,6 @@ namespace Tasha.Validation.PerformanceMeasures;
 
 public class VKTCalc : ISelfContainedModule
 {
-    [RootModule]
-    public ITashaRuntime Root;
 
     [RunParameter("Cost per Km", 0.153f, "What is the cost per km used in this model system?")]
     public float CostPerKm;


### PR DESCRIPTION
In the current implementation VKTCalc has a root module condition for using ITASHARuntime, though it never gets used.
This update removes that condition so it can be used in other model systems.
