### PR TITLE
Multi-Langage Support

### DIFF
--- a/Code/GTAModel/Output/SaveAsCSVMatrix.cs
+++ b/Code/GTAModel/Output/SaveAsCSVMatrix.cs
@@ -18,6 +18,7 @@
 */
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -106,7 +107,7 @@ public class SaveAsCSVMatrix : ISaveODData<float>
                     for ( int j = 0; j < zones.Length; j++ )
                     {
                         zoneLines[i].Append( ',' );
-                        zoneLines[i].Append( data[j + offset] );
+                        zoneLines[i].Append(CultureInfo.InvariantCulture, $"{data[j + offset]}");
                     }
                 } );
             } );

--- a/Code/GTAModel/ParameterDatabase/ModeParameterDatabase.cs
+++ b/Code/GTAModel/ParameterDatabase/ModeParameterDatabase.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using TMG.Functions;
 using XTMF;
 
 namespace TMG.GTAModel;
@@ -260,19 +261,19 @@ public class ModeParameterDatabase : IModeParameterDatabase
                         : parameterMapping[i].Property.PropertyType;
                     if (t == typeof(float))
                     {
-                        parameterMapping[i].Values.Add(float.Parse(parameters[i]));
+                        parameterMapping[i].Values.Add(Utilities.ParseFloat(parameters[i]));
                     }
                     else if (t == typeof(double))
                     {
-                        parameterMapping[i].Values.Add(double.Parse(parameters[i]));
+                        parameterMapping[i].Values.Add(Utilities.ParseDouble(parameters[i]));
                     }
                     else if (t == typeof(bool))
                     {
-                        parameterMapping[i].Values.Add(bool.Parse(parameters[i]));
+                        parameterMapping[i].Values.Add(Utilities.ParseBool(parameters[i]));
                     }
                     else if (t == typeof(int))
                     {
-                        parameterMapping[i].Values.Add(int.Parse(parameters[i]));
+                        parameterMapping[i].Values.Add(Utilities.ParseInt(parameters[i]));
                     }
                 }
             }

--- a/Code/GTAModel/ParameterDatabase/ParameterLink.cs
+++ b/Code/GTAModel/ParameterDatabase/ParameterLink.cs
@@ -18,7 +18,9 @@
 */
 
 using System;
+using System.Globalization;
 using System.Reflection;
+using TMG.Functions;
 using TMG.ParameterDatabase;
 using XTMF;
 
@@ -76,12 +78,12 @@ public class ParameterLink : IParameterLink
         if (TypeIndex == 1)
         {
             // do float assignment
-            temp = float.Parse(value) * Multiplier;
+            temp = Utilities.ParseFloat(value) * Multiplier;
         }
         else if (TypeIndex == 2)
         {
             // do double assignment
-            temp = double.Parse(value) * Multiplier;
+            temp = Utilities.ParseDouble(value) * Multiplier;
         }
         else
         {
@@ -102,29 +104,29 @@ public class ParameterLink : IParameterLink
         }
     }
 
-    public void BlendedAssignment(string value, float ammount)
+    public void BlendedAssignment(string value, float amount)
     {
         var t = (Field != null ? Field.FieldType : Property.PropertyType);
         if (t == typeof(float))
         {
-            if (double.TryParse(value, out double temp))
+            if (Utilities.TryParse(value, out double temp))
             {
                 // do float assignment
-                CurrentBlendNumber += temp * ammount;
+                CurrentBlendNumber += temp * amount;
             }
         }
         else if (t == typeof(double))
         {
-            if (double.TryParse(value, out double temp))
+            if (Utilities.TryParse(value, out double temp))
             {
                 // do float assignment
-                CurrentBlendNumber += temp * ammount;
+                CurrentBlendNumber += temp * amount;
             }
         }
         else if (t == typeof(bool))
         {
             // take the "true'est value
-            if (bool.TryParse(value, out bool temp))
+            if (Utilities.TryParse(value, out bool temp))
             {
                 CurrentBlendBool = CurrentBlendBool | temp;
             }

--- a/Code/NetworkEstimation/CalcMSEofBoardingsAM.cs
+++ b/Code/NetworkEstimation/CalcMSEofBoardingsAM.cs
@@ -17,9 +17,10 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
-using Datastructure;
+using System.Globalization;
 using TMG.Emme;
 using TMG.Estimation;
 using TMG.Input;
@@ -72,7 +73,7 @@ public class CalcMSEofBoardingsAM : IEmmeTool
         {
             var pair = cell.Split(':');
             var lineId = pair[0].Replace("'", "").Trim();
-            float boardings = float.Parse(pair[1]);
+            float boardings = float.Parse(pair[1], CultureInfo.InvariantCulture);
             result[lineId] = boardings;
         }
         return result;

--- a/Code/NetworkEstimation/CalcRMSEofBoardingsAM.cs
+++ b/Code/NetworkEstimation/CalcRMSEofBoardingsAM.cs
@@ -17,9 +17,10 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
-using Datastructure;
+using System.Globalization;
 using TMG.Emme;
 using TMG.Estimation;
 using TMG.Input;
@@ -74,7 +75,7 @@ public class CalcRMSEofBoardingsAM : IEmmeTool
         {
             var pair = cell.Split(':');
             var lineId = pair[0].Replace("'", "").Trim();
-            float boardings = float.Parse(pair[1]);
+            float boardings = float.Parse(pair[1], CultureInfo.InvariantCulture);
             result[lineId] = boardings;
         }
         return result;

--- a/Code/NetworkEstimation/CalcRMSEofBoardingsAMPMWAW.cs
+++ b/Code/NetworkEstimation/CalcRMSEofBoardingsAMPMWAW.cs
@@ -17,11 +17,12 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using Datastructure;
 using TMG.Emme;
 using TMG.Estimation;
 using TMG.Input;
@@ -126,7 +127,7 @@ public class CalcRMSEofBoardingsAMPMWAW : IEmmeTool
                     + cellNumber + ".\r\nThe results were '" + pythonDictionary + "'.");
             }
             var lineId = pair[0].Replace("'", "").Trim();
-            float boardings = float.Parse(pair[1]);
+            float boardings = float.Parse(pair[1], CultureInfo.InvariantCulture);
             result[lineId] = boardings;
             cellNumber++;
         }

--- a/Code/NetworkEstimation/CalcWMPE.cs
+++ b/Code/NetworkEstimation/CalcWMPE.cs
@@ -17,9 +17,10 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
-using Datastructure;
+using System.Globalization;
 using TMG.Emme;
 using TMG.Input;
 using XTMF;
@@ -71,7 +72,7 @@ public class CalcWmpe : IEmmeTool
         {
             var pair = cell.Split(':');
             var lineId = pair[0].Replace("'", "").Trim();
-            float boardings = float.Parse(pair[1]);
+            float boardings = float.Parse(pair[1], CultureInfo.InvariantCulture);
             result[lineId] = boardings;
         }
         return result;

--- a/Code/NetworkEstimation/GeneticNetworkEstimationClient.cs
+++ b/Code/NetworkEstimation/GeneticNetworkEstimationClient.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -193,7 +194,7 @@ public class GeneticNetworkEstimationClient : I4StepModel
                 TransitLine current = new();
                 string currentName;
                 current.Id = [(currentName = split[1])];
-                current.Bordings = float.Parse(split[0]);
+                current.Bordings = float.Parse(split[0], CultureInfo.InvariantCulture);
                 if (split.Length > 2)
                 {
                     current.Mode = split[2][0];
@@ -285,9 +286,9 @@ public class GeneticNetworkEstimationClient : I4StepModel
                     if (attributes != null)
                     {
                         current.ParameterName = attributes["Name"].InnerText;
-                        current.MsNumber = int.Parse(attributes["MS"].InnerText);
-                        current.Start = float.Parse(attributes["Start"].InnerText);
-                        current.Stop = float.Parse(attributes["Stop"].InnerText);
+                        current.MsNumber = int.Parse(attributes["MS"].InnerText, CultureInfo.InvariantCulture);
+                        current.Start = float.Parse(attributes["Start"].InnerText, CultureInfo.InvariantCulture);
+                        current.Stop = float.Parse(attributes["Stop"].InnerText, CultureInfo.InvariantCulture);
                     }
                     current.Current = current.Start;
                     parameters.Add(current);

--- a/Code/NetworkEstimation/GeneticNetworkEstimationHost.cs
+++ b/Code/NetworkEstimation/GeneticNetworkEstimationHost.cs
@@ -509,9 +509,9 @@ public class GeneticNetworkEstimationHost : I4StepModel, IDisposable
                     if (attributes != null)
                     {
                         current.ParameterName = attributes["Name"].InnerText;
-                        current.MsNumber = int.Parse(attributes["MS"].InnerText);
-                        current.Start = float.Parse(attributes["Start"].InnerText);
-                        current.Stop = float.Parse(attributes["Stop"].InnerText);
+                        current.MsNumber = int.Parse(attributes["MS"].InnerText, CultureInfo.InvariantCulture);
+                        current.Start = float.Parse(attributes["Start"].InnerText, CultureInfo.InvariantCulture);
+                        current.Stop = float.Parse(attributes["Stop"].InnerText, CultureInfo.InvariantCulture);
                         current.Current = current.Start;
                         parameters.Add(current);
                     }

--- a/Code/NetworkEstimation/NetworkAI.cs
+++ b/Code/NetworkEstimation/NetworkAI.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 using TMG.Emme;
@@ -354,16 +355,16 @@ public class NetworkAi : INetworkEstimationAI
                 if (split.Length == dimensions + 4)
                 {
                     int offset = split.Length - 3;
-                    float rmse = float.Parse(split[offset + 0]);
-                    float mse = float.Parse(split[offset + 1]);
-                    float error = float.Parse(split[offset + 2]);
+                    float rmse = float.Parse(split[offset + 0], CultureInfo.InvariantCulture);
+                    float mse = float.Parse(split[offset + 1], CultureInfo.InvariantCulture);
+                    float error = float.Parse(split[offset + 2], CultureInfo.InvariantCulture);
                     float value = ErrorCombinationFunction(rmse, mse, error);
                     if (value < BestRunError)
                     {
                         BestRunError = value;
                         for (int i = 0; i < Kernel.Length; i++)
                         {
-                            Kernel[i].Current = float.Parse(split[i]);
+                            Kernel[i].Current = float.Parse(split[i], CultureInfo.InvariantCulture);
                         }
                     }
                 }
@@ -397,7 +398,7 @@ public class NetworkAi : INetworkEstimationAI
                                 if (Kernel[i].ParameterName == pName)
                                 {
 
-                                    Kernel[i].Current = float.Parse(attributes["Value"].InnerText);
+                                    Kernel[i].Current = float.Parse(attributes["Value"].InnerText, CultureInfo.InvariantCulture);
                                     break;
                                 }
                             }

--- a/Code/NetworkEstimation/NetworkEstimationTemplate.cs
+++ b/Code/NetworkEstimation/NetworkEstimationTemplate.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -208,7 +209,7 @@ public class NetworkEstimationTemplate : I4StepModel
                 TransitLine current = new();
                 string currentName;
                 current.Id = [(currentName = split[1])];
-                current.Bordings = float.Parse(split[0]);
+                current.Bordings = float.Parse(split[0], CultureInfo.InvariantCulture);
                 if (split.Length > 2)
                 {
                     current.Mode = split[2][0];
@@ -290,9 +291,9 @@ public class NetworkEstimationTemplate : I4StepModel
                         ParameterSetting current = new()
                         {
                             ParameterName = attributes["Name"].InnerText,
-                            MsNumber = int.Parse(attributes["MS"].InnerText),
-                            Start = float.Parse(attributes["Start"].InnerText),
-                            Stop = float.Parse(attributes["Stop"].InnerText)
+                            MsNumber = int.Parse(attributes["MS"].InnerText, CultureInfo.InvariantCulture),
+                            Start = float.Parse(attributes["Start"].InnerText, CultureInfo.InvariantCulture),
+                            Stop = float.Parse(attributes["Stop"].InnerText, CultureInfo.InvariantCulture)
                         };
                         current.Current = current.Start;
                         parameters.Add(current);

--- a/Code/NetworkEstimation/NetworkGravityDescent.cs
+++ b/Code/NetworkEstimation/NetworkGravityDescent.cs
@@ -18,6 +18,7 @@
 */
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Xml;
 using TMG.Emme;
@@ -226,16 +227,16 @@ public class NetworkGravityDescent : INetworkEstimationAI
                 if (split.Length == dimensions + 4)
                 {
                     int offset = split.Length - 3;
-                    float rmse = float.Parse(split[offset + 0]);
-                    float mse = float.Parse(split[offset + 1]);
-                    float error = float.Parse(split[offset + 2]);
+                    float rmse = float.Parse(split[offset + 0], CultureInfo.InvariantCulture);
+                    float mse = float.Parse(split[offset + 1], CultureInfo.InvariantCulture);
+                    float error = float.Parse(split[offset + 2], CultureInfo.InvariantCulture);
                     float value = ErrorCombinationFunction(rmse, mse, error);
                     if (value < BestRunError)
                     {
                         BestRunError = value;
                         for (int i = 0; i < Kernel.Length; i++)
                         {
-                            Kernel[i].Current = float.Parse(split[i]);
+                            Kernel[i].Current = float.Parse(split[i], CultureInfo.InvariantCulture);
                         }
                     }
                 }
@@ -268,7 +269,7 @@ public class NetworkGravityDescent : INetworkEstimationAI
                             {
                                 if (Kernel[i].ParameterName == pName)
                                 {
-                                    Kernel[i].Current = float.Parse(attributes["Value"].InnerText);
+                                    Kernel[i].Current = float.Parse(attributes["Value"].InnerText, CultureInfo.InvariantCulture);
                                     break;
                                 }
                             }

--- a/Code/NetworkEstimation/V4ClienntEstimationSupplementalReport1.cs
+++ b/Code/NetworkEstimation/V4ClienntEstimationSupplementalReport1.cs
@@ -66,7 +66,7 @@ public class V4ClienntEstimationSupplementalReport1 : ClientFileAggregation, IEm
 
         foreach (var cell in results.Split(','))
         {
-            retVal.Add(float.Parse(cell));
+            retVal.Add(float.Parse(cell, CultureInfo.InvariantCulture));
         }
 
         return retVal;

--- a/Code/TMG.Emme/Network.cs
+++ b/Code/TMG.Emme/Network.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -114,9 +115,9 @@ public class Network : IDisposable
                     {
                         node.IsCentroid = (parts[0].Length >= 2 && parts[0] == "a*");
                     }
-                    node.Number = int.Parse(parts[1 + offset]);
-                    node.X = float.Parse(parts[2 + offset]);
-                    node.Y = float.Parse(parts[3 + offset]);
+                    node.Number = int.Parse(parts[1 + offset], CultureInfo.InvariantCulture);
+                    node.X = float.Parse(parts[2 + offset], CultureInfo.InvariantCulture);
+                    node.Y = float.Parse(parts[3 + offset], CultureInfo.InvariantCulture);
                     if (numberOfParts > 4 + offset)
                     {
                         node.User1 = int.Parse(parts[4 + offset]);
@@ -125,7 +126,7 @@ public class Network : IDisposable
                             node.User2 = int.Parse(parts[5 + offset]);
                             if (numberOfParts > 6 + offset)
                             {
-                                node.NodeType = int.Parse(parts[6 + offset]);
+                                node.NodeType = int.Parse(parts[6 + offset], CultureInfo.InvariantCulture);
                                 node.Modified = false;
                                 if (parts.Length > 7 + offset)
                                 {
@@ -153,13 +154,13 @@ public class Network : IDisposable
                 {
                     var link = new Link(int.Parse(parts[1]), int.Parse(parts[2]))
                     {
-                        Length = float.Parse(parts[3]),
+                        Length = float.Parse(parts[3], CultureInfo.InvariantCulture),
                         Modes = parts[4].ToLower().ToCharArray(),
-                        LinkType = int.Parse(parts[5]),
-                        Lanes = float.Parse(parts[6]),
-                        Vdf = float.Parse(parts[7]),
-                        Speed = float.Parse(parts[9]),
-                        Capacity = float.Parse(parts[10]),
+                        LinkType = int.Parse(parts[5], CultureInfo.InvariantCulture),
+                        Lanes = float.Parse(parts[6], CultureInfo.InvariantCulture),
+                        Vdf = float.Parse(parts[7], CultureInfo.InvariantCulture),
+                        Speed = float.Parse(parts[9], CultureInfo.InvariantCulture),
+                        Capacity = float.Parse(parts[10], CultureInfo.InvariantCulture),
                         Modified = false
                     };
                     // We don't load [8]

--- a/Code/TMG.Emme/TransitLines.cs
+++ b/Code/TMG.Emme/TransitLines.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -71,25 +72,25 @@ public class TransitLines
                     {
                         current.Id = [parts[0]];
                         current.Mode = parts[1][0];
-                        current.VehicalType = int.Parse( parts[2] );
-                        current.NumberOfVehicals = int.Parse( parts[3] );
-                        current.MinHdwy = float.Parse( parts[4] );
-                        current.Length = float.Parse( parts[5] );
-                        current.Time = float.Parse( parts[6] );
-                        current.Bordings = float.Parse( parts[7] );
-                        if ( !float.TryParse( parts[8], out current.KmTraveled ) )
+                        current.VehicalType = int.Parse( parts[2], CultureInfo.InvariantCulture);
+                        current.NumberOfVehicals = int.Parse( parts[3], CultureInfo.InvariantCulture);
+                        current.MinHdwy = float.Parse( parts[4], CultureInfo.InvariantCulture);
+                        current.Length = float.Parse( parts[5], CultureInfo.InvariantCulture);
+                        current.Time = float.Parse( parts[6], CultureInfo.InvariantCulture);
+                        current.Bordings = float.Parse( parts[7], CultureInfo.InvariantCulture);
+                        if ( !float.TryParse( parts[8], CultureInfo.InvariantCulture, out current.KmTraveled ) )
                         {
                             current.KmTraveled = float.PositiveInfinity;
                         }
-                        if ( float.TryParse( parts[9], out current.HoursTraveled ) )
+                        if ( float.TryParse( parts[9], CultureInfo.InvariantCulture, out current.HoursTraveled ) )
                         {
                             current.HoursTraveled = float.PositiveInfinity;
                         }
-                        current.LoadAverage = float.Parse( parts[10] );
-                        current.LoadMax = float.Parse( parts[11] );
-                        current.MaxVolume = float.Parse( parts[12] );
-                        current.OperationCosts = float.Parse( parts[13] );
-                        current.EnergyConsumption = float.Parse( parts[14] );
+                        current.LoadAverage = float.Parse( parts[10], CultureInfo.InvariantCulture);
+                        current.LoadMax = float.Parse( parts[11], CultureInfo.InvariantCulture);
+                        current.MaxVolume = float.Parse( parts[12], CultureInfo.InvariantCulture);
+                        current.OperationCosts = float.Parse( parts[13], CultureInfo.InvariantCulture);
+                        current.EnergyConsumption = float.Parse( parts[14], CultureInfo.InvariantCulture);
                         transitLines.Add( current );
                     }
                     catch

--- a/Code/TMG.Emme/Utilities/ZoneSystemFromNWP.cs
+++ b/Code/TMG.Emme/Utilities/ZoneSystemFromNWP.cs
@@ -28,6 +28,7 @@ using System.IO.Compression;
 using Datastructure;
 using XTMF;
 using TMG.Input;
+using System.Globalization;
 
 namespace TMG.Emme.Utilities;
 
@@ -139,13 +140,20 @@ public sealed class ZoneSystemFromNWP : IZoneSystem, IDisposable
                                 var split = line.Split(seperators, StringSplitOptions.RemoveEmptyEntries);
                                 if (split.Length < 3)
                                 {
-                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones.");
+                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones.  We expected there to be at least three columns, but found {split.Length}!");
                                 }
-                                if (!(int.TryParse(split[1], out int zoneNumber)
-                                    && float.TryParse(split[2], out float x)
-                                    && float.TryParse(split[3], out float y)))
+                                if(!int.TryParse(split[1], CultureInfo.InvariantCulture, out int zoneNumber))
                                 {
-                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones.");
+                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones.  Unable to parse the zone number.");
+                                }
+                                if (!float.TryParse(split[2], CultureInfo.InvariantCulture, out float x))
+                                {
+                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones. Unable to parse the x-coordinate.");
+                                }
+
+                                if (!float.TryParse(split[3], CultureInfo.InvariantCulture, out float y))
+                                {
+                                    throw new XTMFRuntimeException(this, $"Failed to load the line '{line}' when reading in zones. Unable to parse the y-coordinate.");
                                 }
                                 zones.Add(new Zone(zoneNumber, x, y));
                             }

--- a/Code/TMG.Emme/XTMF_Internal/NetworkCalculator.cs
+++ b/Code/TMG.Emme/XTMF_Internal/NetworkCalculator.cs
@@ -18,6 +18,7 @@
 */
 
 using System;
+using System.Globalization;
 using XTMF;
 using TMG.Emme;
 // ReSharper disable UnusedMember.Global
@@ -86,7 +87,7 @@ public sealed class NetworkCalculator : IEmmeTool
         {
             if (SumOfReport != null)
             {
-                if (float.TryParse(result, out float value))
+                if (float.TryParse(result, CultureInfo.InvariantCulture, out float value))
                 {
                     ISetableDataSource<float> dataSource = ((ISetableDataSource<float>)SumOfReport.GetDataSource());
                     if (!dataSource.Loaded)

--- a/Code/TMG.Estimation/BasicParameterLoader.cs
+++ b/Code/TMG.Estimation/BasicParameterLoader.cs
@@ -18,10 +18,12 @@
 */
 using System;
 using System.Collections.Generic;
-using XTMF;
+using System.Globalization;
+using System.IO;
 using System.Xml;
 using TMG.Input;
-using System.IO;
+using XTMF;
+using static TMG.Functions.Utilities;
 
 namespace TMG.Estimation;
 
@@ -85,13 +87,13 @@ public class BasicParameterLoader : IDataSource<List<ParameterSetting>>
                 {
                     throw new XTMFRuntimeException(this, $"In {Name} The Maximum attribute was not defined in {child.OuterXml}!");
                 }
-                current.Minimum = float.Parse( minimumAttribute.InnerText);
-                current.Maximum = float.Parse( maximumAttribute.InnerText);
+                current.Minimum = ParseFloat(minimumAttribute.InnerText);
+                current.Maximum = ParseFloat(maximumAttribute.InnerText);
                 current.Current = current.Minimum;
                 XmlAttribute nullHypothesis;
                 if ( ( nullHypothesis = child.Attributes["NullHypothesis"] ) != null )
                 {
-                    current.NullHypothesis = float.Parse( nullHypothesis.InnerText );
+                    current.NullHypothesis = ParseFloat(nullHypothesis.InnerText);
                 }
                 parameters.Add( current );
             }

--- a/Code/TMG.Frameworks/Data/Processing/AST/Expression.cs
+++ b/Code/TMG.Frameworks/Data/Processing/AST/Expression.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using XTMF;
 
@@ -568,7 +569,7 @@ public abstract class Expression : AstNode
             error = "We were unable to read in a value at position " + start;
             return false;
         }
-        if (float.TryParse(value, out float f))
+        if (float.TryParse(value, CultureInfo.InvariantCulture, out float f))
         {
             // if we can read it in as a floating point number
             ex = new Literal(index, f);

--- a/Code/TMG.Frameworks/Data/Saving/SaveHistogramData.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveHistogramData.cs
@@ -1,5 +1,5 @@
 ﻿/*
-    Copyright 2017 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+    Copyright 2017-2025 Travel Modelling Group, Department of Civil Engineering, University of Toronto
 
     This file is part of XTMF.
 
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -84,6 +85,7 @@ public class SaveHistogramData : ISelfContainedModule
                 }
             }
         }
+        Span<char> buffer = stackalloc char[32];
         using var writer = new StreamWriter(OutputFile);
         writer.WriteLine("Category,Amount");
         for (int i = 0; i < acc.Length; i++)
@@ -93,7 +95,7 @@ public class SaveHistogramData : ISelfContainedModule
             writer.Write(bins[i].ToString());
             writer.Write('"');
             writer.Write(',');
-            writer.WriteLine(acc[i]);
+            Utilities.WriteLine(writer, acc[i], buffer);    
         }
     }
 

--- a/Code/TMG.Frameworks/Data/Saving/SaveInterceptedMatrixToCSV.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveInterceptedMatrixToCSV.cs
@@ -20,6 +20,7 @@ using Datastructure;
 using System;
 using System.IO;
 using System.Threading;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -81,6 +82,7 @@ public sealed class SaveInterceptedMatrixToCSV : IDataSource<SparseTwinIndex<flo
             writer.Write(indexes[i]);
         }
         writer.WriteLine();
+        Span<char> buffer = stackalloc char[32];
         // write data
         for (int i = 0; i < flatData.Length; i++)
         {
@@ -88,7 +90,7 @@ public sealed class SaveInterceptedMatrixToCSV : IDataSource<SparseTwinIndex<flo
             for (int j = 0; j < flatData[i].Length; j++)
             {
                 writer.Write(',');
-                writer.Write(flatData[i][j]);
+                Utilities.Write(writer, flatData[i][j], buffer);
             }
             writer.WriteLine();
         }
@@ -101,6 +103,7 @@ public sealed class SaveInterceptedMatrixToCSV : IDataSource<SparseTwinIndex<flo
         using var writer = new StreamWriter(SaveTo);
         // write header
         writer.WriteLine("O,D,Value");
+        Span<char> buffer = stackalloc char[32];
         // write data
         for (int i = 0; i < flatData.Length; i++)
         {
@@ -110,7 +113,7 @@ public sealed class SaveInterceptedMatrixToCSV : IDataSource<SparseTwinIndex<flo
                 writer.Write(',');
                 writer.Write(indexes[j]);
                 writer.Write(',');
-                writer.WriteLine(flatData[i][j]);
+                Utilities.WriteLine(writer, flatData[i][j], buffer);
             }
         }
     }

--- a/Code/TMG.Frameworks/Data/Saving/SaveInterceptedVectorToCSV.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveInterceptedVectorToCSV.cs
@@ -20,6 +20,7 @@ using Datastructure;
 using System;
 using System.IO;
 using System.Threading;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -61,11 +62,12 @@ public sealed class SaveInterceptedVectorToCSV : IDataSource<SparseArray<float>>
         // write header
         writer.WriteLine("TAZ,Value");
         // write data
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatData.Length; i++)
         {
             writer.Write(indexes[i]);
             writer.Write(',');
-            writer.WriteLine(flatData[i]);
+            Utilities.Write(writer, flatData[i], buffer);
         }
     }
 

--- a/Code/TMG.Frameworks/Data/Saving/SaveLabeledDataToCSV.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveLabeledDataToCSV.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Linq;
 using TMG.Frameworks.Data.DataTypes;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -60,6 +61,7 @@ public class SaveLabeledDataToCSV<T> : ISelfContainedModule
         // now that we have the data save to to disk
         using var writer = new StreamWriter(SaveTo);
         writer.WriteLine("Label,Value");
+        Span<char> buffer = stackalloc char[32];
         // provide an optimized path for float
         if (typeof(T) == typeof(float))
         {
@@ -68,7 +70,7 @@ public class SaveLabeledDataToCSV<T> : ISelfContainedModule
             {
                 writer.Write(element.Key);
                 writer.Write(',');
-                writer.WriteLine(element.Value);
+                Utilities.WriteLine(writer, element.Value, buffer);
             }
         }
         else

--- a/Code/TMG.Frameworks/Data/Saving/SaveMultipleMatricesToCSV.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveMultipleMatricesToCSV.cs
@@ -20,6 +20,7 @@ using Datastructure;
 using System;
 using System.IO;
 using System.Linq;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -48,6 +49,7 @@ public sealed class SaveMultipleMatricesToCSV : ISelfContainedModule
         var zones = Root.ZoneSystem.ZoneArray.GetFlatData().Select(z => z.ZoneNumber).ToArray();
         using var writer = new StreamWriter(SaveTo);
         writer.WriteLine(Header);
+        Span<char> buffer = stackalloc char[32];
         for (var i = 0; i < zones.Length; i++)
         {
             for (var j = 0; j < zones.Length; j++)
@@ -58,7 +60,7 @@ public sealed class SaveMultipleMatricesToCSV : ISelfContainedModule
                 for (var k = 0; k < flatData.Length; k++)
                 {
                     writer.Write(',');
-                    writer.Write(flatData[k][i][j]);
+                    Utilities.Write(writer, flatData[i][j][k], buffer);
                 }
                 writer.WriteLine();
             }

--- a/Code/TMG.Frameworks/Data/Saving/SaveSparseTriIndex.cs
+++ b/Code/TMG.Frameworks/Data/Saving/SaveSparseTriIndex.cs
@@ -18,9 +18,11 @@
 */
 using Datastructure;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -114,7 +116,7 @@ public sealed class SaveSparseTriIndex : ISelfContainedModule
             for (int i = 0; i < data.Length; i++)
             {
                 b.Append(',');
-                b.Append(data[i]);
+                b.Append(CultureInfo.InvariantCulture, $"{data[i]}");
             }
             return b.ToString();
         }
@@ -137,6 +139,7 @@ public sealed class SaveSparseTriIndex : ISelfContainedModule
     {
         using var writer = new StreamWriter(BuildFileName(layerIndex));
         writer.WriteLine("Origin,Destination,Value");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatData.Length; i++)
         {
             for (int j = 0; j < flatData[i].Length; j++)
@@ -145,7 +148,7 @@ public sealed class SaveSparseTriIndex : ISelfContainedModule
                 writer.Write(',');
                 writer.Write(destinations[j]);
                 writer.Write(',');
-                writer.WriteLine(flatData[i][j]);
+                Utilities.WriteLine(writer, flatData[i][j], buffer);
             }
         }
     }

--- a/Code/TMG.Frameworks/MultiRun/MultiRunModelSystem.cs
+++ b/Code/TMG.Frameworks/MultiRun/MultiRunModelSystem.cs
@@ -18,14 +18,15 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Xml;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
-using TMG.Functions;
-using System.Threading;
 // ReSharper disable CompareOfFloatsByEqualityOperator
 
 namespace TMG.Frameworks.MultiRun;
@@ -633,7 +634,7 @@ public class MultiRunModelSystem : IModelSystemTemplate
     {
         var name = GetAttributeOrError(command, "Name", "The name of the variable was not given!\r\n" + command.OuterXml);
         var value = GetAttributeOrError(command, "Value", "The value to assign the variable was not given!\r\n" + command.OuterXml);
-        if (!float.TryParse(value, out float fValue))
+        if (!float.TryParse(value, CultureInfo.InvariantCulture, out float fValue))
         {
             throw new XTMFRuntimeException(this, $"In '{Name}' we were unable to extract the value of {value} into a number!\r\n{command.OuterXml}");
         }
@@ -646,7 +647,7 @@ public class MultiRunModelSystem : IModelSystemTemplate
         {
             return value;
         }
-        if (float.TryParse(name, out value))
+        if (float.TryParse(name, CultureInfo.InvariantCulture, out value))
         {
             return value;
         }

--- a/Code/TMG.Functions/SaveData.cs
+++ b/Code/TMG.Functions/SaveData.cs
@@ -25,6 +25,7 @@ using Datastructure;
 using TMG.Input;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace TMG.Functions;
 
@@ -78,7 +79,7 @@ public static class SaveData
                         for (int j = 0; j < zones.Length; j++)
                         {
                             zoneLines[i].Append(',');
-                            zoneLines[i].Append(row[j]);
+                            zoneLines[i].Append(CultureInfo.InvariantCulture, $"{ row[j]}");
                         }
                     }
                 });
@@ -101,11 +102,12 @@ public static class SaveData
         var flatData = data.GetFlatData();
         var indexes = data.ValidIndexArray().Select(index => index.ToString()).ToArray();
         using StreamWriter writer = new(saveTo, false, Encoding.UTF8);
-        void WriteRecord(string zone, float value)
+        Span<char> buffer = stackalloc char[32];
+        void WriteRecord(string zone, float value, Span<char> buffer)
         {
             writer.Write(zone);
             writer.Write(',');
-            writer.WriteLine(value);
+            Utilities.WriteLine(writer, value, buffer);
         }
         writer.WriteLine("Zone,Value");
         if (skipZeros)
@@ -114,7 +116,7 @@ public static class SaveData
             {
                 if (flatData[i] != 0)
                 {
-                    WriteRecord(indexes[i], flatData[i]);
+                    WriteRecord(indexes[i], flatData[i], buffer);
                 }
             }
         }
@@ -122,7 +124,7 @@ public static class SaveData
         {
             for (int i = 0; i < flatData.Length; i++)
             {
-                WriteRecord(indexes[i], flatData[i]);
+                WriteRecord(indexes[i], flatData[i], buffer);
             }
         }
     }
@@ -136,13 +138,14 @@ public static class SaveData
     {
         var zoneNumbers = zones.Select(z => z.ZoneNumber.ToString()).ToArray();
         using StreamWriter writer = new(saveLocation, false, Encoding.UTF8);
-        void WriteRecord(string origin, string destination, float value)
+        Span<char> buffer = stackalloc char[32];
+        void WriteRecord(string origin, string destination, float value, Span<char> buffer)
         {
             writer.Write(origin);
             writer.Write(',');
             writer.Write(destination);
             writer.Write(',');
-            writer.WriteLine(value);
+            Utilities.WriteLine(writer, value, buffer);
         }
         writer.WriteLine("Origin,Destination,Data");
         for (int i = 0; i < data.Length; i++)
@@ -154,7 +157,7 @@ public static class SaveData
                 {
                     if (row[j] != 0)
                     {
-                        WriteRecord(zoneNumbers[i], zoneNumbers[j], row[j]);
+                        WriteRecord(zoneNumbers[i], zoneNumbers[j], row[j], buffer);
                     }
                 }
             }
@@ -162,7 +165,7 @@ public static class SaveData
             {
                 for (int j = 0; j < row.Length; j++)
                 {
-                    WriteRecord(zoneNumbers[i], zoneNumbers[j], row[j]);
+                    WriteRecord(zoneNumbers[i], zoneNumbers[j], row[j], buffer);
                 }
             }
         }
@@ -177,13 +180,14 @@ public static class SaveData
     {
         using StreamWriter writer = new(saveLocation, false, Encoding.UTF8);
         writer.WriteLine("Origin,Destination,Data");
-        void WriteRecord(int origin, int destination, float value)
+        Span<char> buffer = stackalloc char[32];
+        void WriteRecord(int origin, int destination, float value, Span<char> buffer)
         {
             writer.Write(origin);
             writer.Write(',');
             writer.Write(destination);
             writer.Write(',');
-            writer.WriteLine(value);
+            Utilities.WriteLine(writer, value, buffer);
         }
         foreach (var o in matrix.ValidIndexes())
         {
@@ -194,7 +198,7 @@ public static class SaveData
                     var entry = matrix[o, d];
                     if (entry != 0.0)
                     {
-                        WriteRecord(o, d, entry);
+                        WriteRecord(o, d, entry, buffer);
                     }
                 }
             }
@@ -202,7 +206,7 @@ public static class SaveData
             {
                 foreach (var d in matrix.ValidIndexes(o))
                 {
-                    WriteRecord(o, d, matrix[o, d]);
+                    WriteRecord(o, d, matrix[o, d], buffer);
                 }
             }
         }
@@ -287,7 +291,7 @@ public static class SaveData
                 for (int j = 0; j < row.Length; j++)
                 {
                     strBuilder.Append(',');
-                    strBuilder.Append(row[j]);
+                    strBuilder.Append(CultureInfo.InvariantCulture, $"{row[j]}");
                 }
             }
             toWrite.Add(new SaveTask() { RowNumber = i + 1, Text = strBuilder.ToString() });
@@ -337,7 +341,7 @@ public static class SaveData
                     for (int j = 0; j < zones.Length; j++)
                     {
                         zoneLines[i].Append(',');
-                        zoneLines[i].Append(data[iOffset + j]);
+                        zoneLines[i].Append(CultureInfo.InvariantCulture, $"{data[iOffset + j]}");
                     }
                 });
             });

--- a/Code/TMG.Functions/Utilities.cs
+++ b/Code/TMG.Functions/Utilities.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Globalization;
+
+namespace TMG.Functions;
+
+/// <summary>
+/// This class contains utility functions that would exist across libraries.
+/// </summary>
+public static class Utilities
+{
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static float ParseFloat(ReadOnlySpan<char> str)
+    {
+        if (!float.TryParse(str, out float value))
+        {
+            _ = float.TryParse(str, CultureInfo.InvariantCulture, out value);
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static double ParseDouble(ReadOnlySpan<char> str)
+    {
+        if (!double.TryParse(str, out double value))
+        {
+            _ = double.TryParse(str, CultureInfo.InvariantCulture, out value);
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static int ParseInt(ReadOnlySpan<char> str)
+    {
+        if (!int.TryParse(str, out int value))
+        {
+            _ = int.TryParse(str, CultureInfo.InvariantCulture, out value);
+        }
+        return value;
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static bool ParseBool(ReadOnlySpan<char> str)
+    {
+        // There is only the invariant culture for bool parsing in .NET at the moment.
+        _ = bool.TryParse(str, out bool value);
+        return value;
+    }
+
+}

--- a/Code/TMG.Functions/Utilities.cs
+++ b/Code/TMG.Functions/Utilities.cs
@@ -29,6 +29,21 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    public static bool TryParse(ReadOnlySpan<char> str, out float result)
+    {
+        if (float.TryParse(str, out result))
+        {
+            return true;
+        }
+        return float.TryParse(str, CultureInfo.InvariantCulture, out result);
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
     public static double ParseDouble(ReadOnlySpan<char> str)
     {
         if (!double.TryParse(str, out double value))
@@ -36,6 +51,21 @@ public static class Utilities
             _ = double.TryParse(str, CultureInfo.InvariantCulture, out value);
         }
         return value;
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static bool TryParse(ReadOnlySpan<char> str, out double result)
+    {
+        if (double.TryParse(str, out result))
+        {
+            return true;
+        }
+        return double.TryParse(str, CultureInfo.InvariantCulture, out result);
     }
 
     /// <summary>
@@ -59,11 +89,38 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    public static bool TryParse(ReadOnlySpan<char> str, out int result)
+    {
+        if (int.TryParse(str, out result))
+        {
+            return true;
+        }
+        return int.TryParse(str, CultureInfo.InvariantCulture, out result);
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
     public static bool ParseBool(ReadOnlySpan<char> str)
     {
         // There is only the invariant culture for bool parsing in .NET at the moment.
         _ = bool.TryParse(str, out bool value);
         return value;
+    }
+
+    /// <summary>
+    /// Reads a float by trying to parse in the system language,
+    /// if that fails it will then try again with the invariant culture.
+    /// </summary>
+    /// <param name="str">The string to parse</param>
+    /// <returns></returns>
+    public static bool TryParse(ReadOnlySpan<char> str, out bool result)
+    {
+        // There is only the invariant culture for bool parsing in .NET at the moment.
+        return bool.TryParse(str, out result);
     }
 
 }

--- a/Code/TMG.Functions/Utilities.cs
+++ b/Code/TMG.Functions/Utilities.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace TMG.Functions;
 
@@ -14,6 +16,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static float ParseFloat(ReadOnlySpan<char> str)
     {
         if (!float.TryParse(str, out float value))
@@ -29,6 +32,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static bool TryParse(ReadOnlySpan<char> str, out float result)
     {
         if (float.TryParse(str, out result))
@@ -44,6 +48,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static double ParseDouble(ReadOnlySpan<char> str)
     {
         if (!double.TryParse(str, out double value))
@@ -59,6 +64,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static bool TryParse(ReadOnlySpan<char> str, out double result)
     {
         if (double.TryParse(str, out result))
@@ -74,6 +80,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static int ParseInt(ReadOnlySpan<char> str)
     {
         if (!int.TryParse(str, out int value))
@@ -89,6 +96,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static bool TryParse(ReadOnlySpan<char> str, out int result)
     {
         if (int.TryParse(str, out result))
@@ -104,6 +112,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static bool ParseBool(ReadOnlySpan<char> str)
     {
         // There is only the invariant culture for bool parsing in .NET at the moment.
@@ -117,10 +126,51 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
     public static bool TryParse(ReadOnlySpan<char> str, out bool result)
     {
         // There is only the invariant culture for bool parsing in .NET at the moment.
         return bool.TryParse(str, out result);
+    }
+
+    /// <summary>
+    /// Writes a float to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    public static void Write(StreamWriter writer, float data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Writes a float to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteLine(StreamWriter writer, float data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString());
+        }
     }
 
 }

--- a/Code/Tasha.Validation/Scheduler/SaveTripLengthFrequencyDistribution.cs
+++ b/Code/Tasha.Validation/Scheduler/SaveTripLengthFrequencyDistribution.cs
@@ -92,6 +92,7 @@ public sealed class SaveTripLengthFrequencyDistribution : ISelfContainedModule
         // Save the results to file
         try
         {
+            Span<char> buffer = stackalloc char[32];
             using var writer = new StreamWriter(SaveTo);
             writer.WriteLine("Min,Max,Value");
             writer.Write("intrazonal,0,");
@@ -102,7 +103,7 @@ public sealed class SaveTripLengthFrequencyDistribution : ISelfContainedModule
                 writer.Write(',');
                 writer.Write((i + 1) * Stride);
                 writer.Write(',');
-                writer.WriteLine(bins[i]);
+                TMG.Functions.Utilities.WriteLine(writer, bins[i], buffer);
             }
             writer.Write(Stride * bins.Length);
             writer.Write(",inf,");

--- a/Code/XTMFInterfaces/Attributes/ArbitraryParameterParser.cs
+++ b/Code/XTMFInterfaces/Attributes/ArbitraryParameterParser.cs
@@ -123,8 +123,12 @@ public static class ArbitraryParameterParser
         {
             if (!float.TryParse(input, NumberStyles.Any, _numberFormat, out ret))
             {
-                error = $"Unable to parse '{input}' as a floating point number!";
-                return null;
+                if (!float.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out ret))
+                {
+                    // If we still can't parse it, return an error
+                    error = $"Unable to parse '{input}' as a floating point number!";
+                    return null;
+                }
             }
         }
         return ret;
@@ -136,8 +140,12 @@ public static class ArbitraryParameterParser
         {
             if (!double.TryParse(input, NumberStyles.Any, _numberFormat, out ret))
             {
-                error = $"Unable to parse '{input}' as a floating point number!";
-                return null;
+                if (!double.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture, out ret))
+                {
+                    // If we still can't parse it, return an error
+                    error = $"Unable to parse '{input}' as a floating point number!";
+                    return null;
+                }
             }
         }
         return ret;

--- a/Code/XTMFTesting/CSVReaderTest.cs
+++ b/Code/XTMFTesting/CSVReaderTest.cs
@@ -16,69 +16,73 @@
     You should have received a copy of the GNU General Public License
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
-using System.IO.Compression;
 using Datastructure;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Compression;
 
 namespace XTMF.Testing;
 
 [TestClass]
 public class CSVReaderTest
 {
-    private string[] TestCSVFileNames = ["CSVTest1.csv", "CSVTest2.csv", "CSVTest3.csv", "CSVTest4.csv", "CSVTest5.csv", "CSVTest6.csv.gz"];
+    private string[] TestCSVFileNames = ["CSVTest1.csv", "CSVTest2.csv", "CSVTest3.csv", "CSVTest4.csv", "CSVTest5.csv", "CSVTest6.csv.gz", "CSVTest6-FR.csv.gz"];
 
     [TestInitialize]
     public void CreateTestEnvironment()
     {
-        if ( !IsEnvironmentLoaded() )
+        using (StreamWriter writer = new(TestCSVFileNames[0]))
         {
-            using ( StreamWriter writer = new( TestCSVFileNames[0] ) )
-            {
-                writer.WriteLine( "A,B,C,D,E" );
-                writer.WriteLine( "1,2,3,4,5" );
-                writer.WriteLine( "3,1,4,5,2" );
-                writer.WriteLine( "1.23,4.56,7.89,10.1112,0.1314" );
-            }
-            using ( StreamWriter writer = new( TestCSVFileNames[1] ) )
-            {
-                writer.WriteLine( "\"A\",\"B\",\"C\",\"D\",\"E\"" );
-                writer.WriteLine( "\"1\",\"2\",3,\"4\",5" );
-                writer.WriteLine( "3,1,\"4\",5,2" );
-                writer.WriteLine( "1.23,\"4.56\",7.89,10.1112,0.1314" );
-            }
-            using ( StreamWriter writer = new( TestCSVFileNames[2] ) )
-            {
-                writer.WriteLine( "A,B,C,D,E" );
-                writer.WriteLine( "1,2,3,4,5" );
-                writer.WriteLine( "3,1,4,5,2" );
-                writer.WriteLine( "1.23,4.56,7.89,10.1112,0.1314" );
-            }
-            using (StreamWriter writer = new(TestCSVFileNames[3]))
-            {
-                writer.WriteLine("A,B,C,D,E");
-                writer.WriteLine("1,2,3,4,5");
-                writer.WriteLine("3,1,4,5,2");
-                writer.Write("1.23,4.56,7.89,10.1112,0.1314");
-            }
-            using (StreamWriter writer = new(TestCSVFileNames[4]))
-            {
-                writer.WriteLine("A,B,C,D,E");
-                writer.WriteLine("\"abc\"\"1\",2,3,4,5");
-            }
-            using (StreamWriter writer = new(new GZipStream(File.Open(TestCSVFileNames[5], FileMode.Create, FileAccess.Write), CompressionMode.Compress)))
-            {
-                writer.WriteLine("A,B,C,D,E");
-                writer.WriteLine("1,2,3,4,5");
-                writer.WriteLine("3,1,4,5,2");
-                writer.WriteLine("1.23,4.56,7.89,10.1112,0.1314");
-            }
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("1,2,3,4,5");
+            writer.WriteLine("3,1,4,5,2");
+            writer.WriteLine("1.23,4.56,7.89,10.1112,0.1314");
+        }
+        using (StreamWriter writer = new(TestCSVFileNames[1]))
+        {
+            writer.WriteLine("\"A\",\"B\",\"C\",\"D\",\"E\"");
+            writer.WriteLine("\"1\",\"2\",3,\"4\",5");
+            writer.WriteLine("3,1,\"4\",5,2");
+            writer.WriteLine("1.23,\"4.56\",7.89,10.1112,0.1314");
+        }
+        using (StreamWriter writer = new(TestCSVFileNames[2]))
+        {
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("1,2,3,4,5");
+            writer.WriteLine("3,1,4,5,2");
+            writer.WriteLine("1.23,4.56,7.89,10.1112,0.1314");
+        }
+        using (StreamWriter writer = new(TestCSVFileNames[3]))
+        {
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("1,2,3,4,5");
+            writer.WriteLine("3,1,4,5,2");
+            writer.Write("1.23,4.56,7.89,10.1112,0.1314");
+        }
+        using (StreamWriter writer = new(TestCSVFileNames[4]))
+        {
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("\"abc\"\"1\",2,3,4,5");
+        }
+        using (StreamWriter writer = new(new GZipStream(File.Open(TestCSVFileNames[5], FileMode.Create, FileAccess.Write), CompressionMode.Compress)))
+        {
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("1,2,3,4,5");
+            writer.WriteLine("1.23,4.56,7.89,10.1112,0.1314");
+        }
+        using (StreamWriter writer = new(new GZipStream(File.Open(TestCSVFileNames[6], FileMode.Create, FileAccess.Write), CompressionMode.Compress)))
+        {
+            writer.WriteLine("A,B,C,D,E");
+            writer.WriteLine("1,2,3,4,5");
+            writer.WriteLine("\"1,23\",\"4,56\",\"7.89\",\"10,1112\",\"0,1314\"");
         }
     }
 
     public bool IsEnvironmentLoaded()
     {
-        for ( int i = 0; i < TestCSVFileNames.Length; i++ )
+        for (int i = 0; i < TestCSVFileNames.Length; i++)
         {
-            if ( !File.Exists( TestCSVFileNames[i] ) ) return false;
+            if (!File.Exists(TestCSVFileNames[i])) return false;
         }
         return true;
     }
@@ -223,6 +227,78 @@ public class CSVReaderTest
         {
             reader.Get(out string s, i);
             Assert.AreEqual(new String((char)('A' + i), 1), s);
+        }
+    }
+
+    [TestMethod]
+    public void TestReadingFrenchCSV()
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-ca");
+        try
+        {
+            using CsvReader reader = new(TestCSVFileNames[6]);
+            Span<float> expectedValues = [1.23f, 4.56f, 7.89f, 10.1112f, 0.1314f];
+            reader.LoadLine();
+            //"A,B,C,D,E"
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out string s, i);
+                Assert.AreEqual(new String((char)('A' + i), 1), s);
+            }
+            reader.LoadLine();
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out int n, i);
+                Assert.AreEqual(i + 1, n);
+            }
+            reader.LoadLine(out int columns);
+            Assert.AreEqual(5, columns);
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out float value, i);
+                Assert.AreEqual(expectedValues[i], value, 0.0001f, $"Value at index {i} did not match expected value.");
+            }
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+
+    [TestMethod]
+    public void TestReadingEnglishCSVWithFrenchLanguage()
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-ca");
+        try
+        {
+            using CsvReader reader = new(TestCSVFileNames[5]);
+            Span<float> expectedValues = [1.23f, 4.56f, 7.89f, 10.1112f, 0.1314f];
+            reader.LoadLine();
+            //"A,B,C,D,E"
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out string s, i);
+                Assert.AreEqual(new String((char)('A' + i), 1), s);
+            }
+            reader.LoadLine();
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out int n, i);
+                Assert.AreEqual(i + 1, n);
+            }
+            reader.LoadLine(out int columns);
+            Assert.AreEqual(5, columns);
+            for (int i = 0; i < 5; i++)
+            {
+                reader.Get(out float value, i);
+                Assert.AreEqual(expectedValues[i], value, 0.0001f, $"Value at index {i} did not match expected value.");
+            }
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
         }
     }
 }

--- a/Code/XTMFTesting/ODCTesting.cs
+++ b/Code/XTMFTesting/ODCTesting.cs
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
+using System.Globalization;
 using System.Text;
 using Datastructure;
 // ReSharper disable CompareOfFloatsByEqualityOperator
@@ -204,9 +205,9 @@ public class ODCTesting
         {
             for (int j = 0; j < numberOfZones; j++)
             {
-                builder.AppendFormat("{0,7}", zones[i]);
-                builder.AppendFormat("{0,7} ", zones[j]);
-                builder.AppendFormat("{0,9}", data[i][j]);
+                builder.AppendFormat(CultureInfo.InvariantCulture, "{0,7}", zones[i]);
+                builder.AppendFormat(CultureInfo.InvariantCulture, "{0,7} ", zones[j]);
+                builder.AppendFormat(CultureInfo.InvariantCulture, "{0,9}", data[i][j]);
                 var size = builder.Length;
                 if (size >= buff.Length)
                 {
@@ -234,7 +235,7 @@ public class ODCTesting
                 builder.Append(',');
                 builder.Append(zones[j]);
                 builder.Append(',');
-                builder.Append(data[i][j]);
+                builder.Append(CultureInfo.InvariantCulture, $"{data[i][j]}");
                 var size = builder.Length;
                 if (size >= buff.Length)
                 {

--- a/Datastructure/CsvParse.cs
+++ b/Datastructure/CsvParse.cs
@@ -1,5 +1,5 @@
 /*
-    Copyright 2014 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+    Copyright 2014-2025 Travel Modelling Group, Department of Civil Engineering, University of Toronto
 
     This file is part of XTMF.
 
@@ -17,127 +17,29 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Datastructure;
 
 internal static class CsvParse
 {
-    internal static float ParseFixedFloat(string line, int offset, int length)
+
+    internal static float ParseFloat(ReadOnlySpan<char> line)
     {
-        var start = offset + length;
-        var scientificNotation = false;
-        var exponent = 0;
-        while ( start > 0 && ( ( line[start - 1] >= '0' & line[start - 1] <= '9' ) | line[start - 1] == '.' | line[start - 1] == '-' | line[start - 1] == '+' ) )
+        if (!float.TryParse(line, out float value))
         {
-            if ( start > 2 && ( line[start - 1] == '-' & ( line[start - 2] == 'e' | line[start - 2] == 'E' ) ) )
-            {
-                scientificNotation = true;
-                exponent = -ParseInt( line, start, offset + length );
-                // subtract
-                length -= ( offset + length ) - start + 2;
-                start -= 2;
-            }
-            else if ( start > 2 && ( line[start - 1] == '+' & ( line[start - 2] == 'e' | line[start - 2] == 'E' ) ) )
-            {
-                scientificNotation = true;
-                exponent = ParseInt( line, start, offset + length );
-                // subtract
-                length -= ( offset + length ) - start + 2;
-                start -= 2;
-            }
-            else
-            {
-                start--;
-            }
+            _ = float.TryParse(line, CultureInfo.InvariantCulture, out value);
         }
-        if ( scientificNotation )
-        {
-            return (float)Math.Pow( 10, exponent ) * ParseFloat( line, start, offset + length );
-        }
-        else
-        {
-            return ParseFloat( line, start, offset + length );
-        }
+        return value;
     }
 
-    internal static float ParseFixedFloat(StringBuilder line, int offset, int length)
-    {
-        var start = offset + length;
-        var scientificNotation = false;
-        var exponent = 0;
-        while ( start > 0 && ( ( line[start - 1] >= '0' & line[start - 1] <= '9' ) | line[start - 1] == '.' | line[start - 1] == '-' | line[start - 1] == '+' ) )
-        {
-            if ( start > 2 && ( line[start - 1] == '-' & ( line[start - 2] == 'e' | line[start - 2] == 'E' ) ) )
-            {
-                scientificNotation = true;
-                exponent = -ParseInt( line, start, offset + length );
-                // subtract
-                length -= ( offset + length ) - start + 2;
-                start -= 2;
-            }
-            else if ( start > 2 && ( line[start - 1] == '+' & ( line[start - 2] == 'e' | line[start - 2] == 'E' ) ) )
-            {
-                scientificNotation = true;
-                exponent = ParseInt( line, start, offset + length );
-                // subtract
-                length -= ( offset + length ) - start + 2;
-                start -= 2;
-            }
-            else
-            {
-                start--;
-            }
-        }
-        if ( scientificNotation )
-        {
-            return (float)Math.Pow( 10, exponent ) * ParseFloat( line, start, offset + length );
-        }
-        else
-        {
-            return ParseFloat( line, start, offset + length );
-        }
-    }
-
+    [MethodImpl(MethodImplOptions.NoInlining)]
     internal static float ParseFixedFloat(char[] line, int offset, int length)
     {
-        var start = offset + length;
-        var scientificNotation = false;
-        var exponent = 0;
-        while ( start > 0 && ( ( line[start - 1] >= '0' & line[start - 1] <= '9' ) | line[start - 1] == '.' | line[start - 1] == '-' | line[start - 1] == '+' ) )
-        {
-            if ( start > 2 && ( line[start - 2] == 'e' | line[start - 2] == 'E' ) )
-            {
-                if ( line[start - 1] == '-' )
-                {
-                    exponent = -ParseInt( line, start, offset + length );
-                }
-                else if ( line[start - 1] == '+' )
-                {
-                    exponent = ParseInt( line, start, offset + length );
-                }
-                else
-                {
-                    break;
-                }
-                scientificNotation = true;
-                // subtract
-                length = ( offset + length ) - start + 2;
-                start -= 2;
-            }
-            else
-            {
-                start--;
-            }
-        }
-        if ( scientificNotation )
-        {
-            return (float)Math.Pow( 10, exponent ) * ParseFloat( line, start, offset + length );
-        }
-        else
-        {
-            return ParseFloat( line, start, offset + length );
-        }
+        var buffer = line.AsSpan(offset, length);
+        return ParseFloat(buffer);
     }
 
     internal static int ParseFixedInt(string line, int offset, int length)
@@ -179,31 +81,8 @@ internal static class CsvParse
     /// <returns></returns>
     internal static float ParseFloat(string str, int indexFrom, int indexTo)
     {
-        var ival = 0;
-        float fval = 0;
-        var multiplyer = 0.1f;
-        int i;
-        char c;
-        var neg = str[indexFrom] == '-';
-        if ( neg ) indexFrom++;
-        for ( i = indexFrom; i < indexTo; i++ )
-        {
-            if ( ( c = str[i] ) == '.' )
-            {
-                break;
-            }
-            // Same as multiplying by 10
-            ival = ( ival << 1 ) + ( ival << 3 );
-            ival += c - '0';
-        }
-        for ( i++; i < indexTo; i++ )
-        {
-            var k = ( str[i] - '0' );
-            fval += k * multiplyer;
-            multiplyer *= 0.1f;
-        }
-        fval += ival;
-        return neg ? -fval : fval;
+        var buffer = str.AsSpan(indexFrom, indexTo - indexFrom);
+        return ParseFloat(buffer);
     }
 
     /// <summary>
@@ -215,31 +94,10 @@ internal static class CsvParse
     /// <returns></returns>
     internal static float ParseFloat(StringBuilder str, int indexFrom, int indexTo)
     {
-        var ival = 0;
-        float fval = 0;
-        var multiplyer = 0.1f;
-        int i;
-        char c;
-        var neg = str[indexFrom] == '-';
-        if ( neg ) indexFrom++;
-        for ( i = indexFrom; i < indexTo; i++ )
-        {
-            if ( ( c = str[i] ) == '.' )
-            {
-                break;
-            }
-            // Same as multiplying by 10
-            ival = ( ival << 1 ) + ( ival << 3 );
-            ival += c - '0';
-        }
-        for ( i++; i < indexTo; i++ )
-        {
-            var k = ( str[i] - '0' );
-            fval += k * multiplyer;
-            multiplyer *= 0.1f;
-        }
-        fval += ival;
-        return neg ? -fval : fval;
+        var length = indexTo - indexFrom;
+        Span<char> buffer = stackalloc char[length];
+        str.CopyTo(indexFrom, buffer, length);
+        return ParseFloat(buffer);
     }
 
     /// <summary>
@@ -251,31 +109,8 @@ internal static class CsvParse
     /// <returns></returns>
     internal static float ParseFloat(char[] str, int indexFrom, int indexTo)
     {
-        var ival = 0;
-        float fval = 0;
-        var multiplyer = 0.1f;
-        int i;
-        char c;
-        var neg = str[indexFrom] == '-';
-        if ( neg ) indexFrom++;
-        for ( i = indexFrom; i < indexTo; i++ )
-        {
-            if ( ( c = str[i] ) == '.' )
-            {
-                break;
-            }
-            // Same as multiplying by 10
-            ival = ( ival << 1 ) + ( ival << 3 );
-            ival += c - '0';
-        }
-        for ( i++; i < indexTo; i++ )
-        {
-            var k = ( str[i] - '0' );
-            fval += k * multiplyer;
-            multiplyer *= 0.1f;
-        }
-        fval += ival;
-        return neg ? -fval : fval;
+        var buffer = str.AsSpan(indexFrom, indexTo - indexFrom);
+        return ParseFloat(buffer);
     }
 
     /// <summary>

--- a/Datastructure/CsvReader.cs
+++ b/Datastructure/CsvReader.cs
@@ -20,6 +20,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -128,6 +129,7 @@ public sealed class CsvReader : IDisposable
     /// </summary>
     /// <param name="item">Where to put the data</param>
     /// <param name="pos">Which column to read from, 0 indexed</param>
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public void Get(out float item, int pos)
     {
         int first;

--- a/Datastructure/FastParse.cs
+++ b/Datastructure/FastParse.cs
@@ -17,11 +17,21 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Globalization;
 
 namespace Datastructure;
 
 public static class FastParse
 {
+    public static float ParseFloat(ReadOnlySpan<char> str)
+    {
+        if (!float.TryParse(str, out float value))
+        {
+            _ = float.TryParse(str, CultureInfo.InvariantCulture, out value);
+        }
+        return value;
+    }
+
     public static float ParseFixedFloat(string line, int offset, int length)
     {
         var start = offset + length;

--- a/ODCache/ODCCreator.cs
+++ b/ODCache/ODCCreator.cs
@@ -17,7 +17,9 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -307,7 +309,7 @@ public class OdcCreator
             {
                 if (data[i] == "") break;
 
-                Data[o][d][injectIndex + entry] = float.Parse(data[i]);
+                Data[o][d][injectIndex + entry] = FastParse.ParseFloat(data[i]);
                 HasData[o][d] = true;
                 entry++;
             }

--- a/ODCache/ODCCreator2.cs
+++ b/ODCache/ODCCreator2.cs
@@ -149,7 +149,7 @@ public class OdcCreator2<T>
             int entry = 0;
             for (int i = 2; i < data.Length; i++)
             {
-                position[injectIndex + entry] = float.Parse(data[i]);
+                position[injectIndex + entry] = FastParse.ParseFloat(data[i]);
                 entry++;
             }
         }

--- a/Tasha/Estimation/EstimationHouseholdLoader.cs
+++ b/Tasha/Estimation/EstimationHouseholdLoader.cs
@@ -28,6 +28,7 @@ using TMG;
 using XTMF;
 using XTMF.Networking;
 using System.Threading.Tasks;
+using System.Globalization;
 // ReSharper disable InconsistentNaming
 
 namespace Tasha.Estimation;
@@ -228,11 +229,11 @@ public class EstimationHouseholdLoader : IDataLoader<ITashaHousehold>
                     break;
 
                 case "System.Single":
-                    att.Attach(name, float.Parse(text));
+                    att.Attach(name, float.Parse(text, CultureInfo.InvariantCulture));
                     break;
 
                 case "System.Int32":
-                    att.Attach(name, int.Parse(text));
+                    att.Attach(name, int.Parse(text, CultureInfo.InvariantCulture));
                     break;
             }
         }

--- a/Tasha/Estimation/HostHouseholdLoader.cs
+++ b/Tasha/Estimation/HostHouseholdLoader.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -262,8 +263,20 @@ public class HostHouseholdLoader : IDataLoader<ITashaHousehold>
             }
             else
             {
-                writer.Write(o.GetType().FullName);
-                writer.Write(o.ToString());
+                var type = o.GetType();
+                writer.Write(type.FullName);
+                if (o is float f)
+                {
+                    writer.Write(f.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (o is double d)
+                {
+                    writer.Write(d.ToString(CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    writer.Write(o.ToString());
+                }
             }
         }
     }

--- a/Tasha/Estimation/TestParameterSignificance.cs
+++ b/Tasha/Estimation/TestParameterSignificance.cs
@@ -17,14 +17,15 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
-using System.Text;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Xml;
 using Tasha.Common;
+using Tasha.XTMFModeChoice;
 using TMG.Input;
 using XTMF;
-using Tasha.XTMFModeChoice;
 
 namespace Tasha.Estimation;
 
@@ -396,7 +397,7 @@ public class TestParameterSignificance : IPostHousehold
                 {
                     if (localParameters[j].Names[k] == header[i])
                     {
-                        if (!float.TryParse(parameters[i], out localParameters[j].Current))
+                        if (!float.TryParse(parameters[i], CultureInfo.InvariantCulture, out localParameters[j].Current))
                         {
                             throw new XTMFRuntimeException(this, "In '" + Name
                                 + "' we were unable to read in the parameter, '" + parameters[i]

--- a/Tasha/ModeChoiceEstimationClient.cs
+++ b/Tasha/ModeChoiceEstimationClient.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -547,11 +548,11 @@ public class ModeChoiceEstimationClient : ITashaRuntime
                     break;
 
                 case "System.Single":
-                    att.Attach(name, float.Parse(text));
+                    att.Attach(name, float.Parse(text, CultureInfo.InvariantCulture));
                     break;
 
                 case "System.Int32":
-                    att.Attach(name, int.Parse(text));
+                    att.Attach(name, int.Parse(text, CultureInfo.InvariantCulture));
                     break;
             }
         }

--- a/Tasha/ModeChoiceEstimationHost.cs
+++ b/Tasha/ModeChoiceEstimationHost.cs
@@ -26,6 +26,7 @@ using System.Xml;
 using Datastructure;
 using Tasha.Common;
 using TMG;
+using static TMG.Functions.Utilities;
 using TMG.Input;
 using XTMF;
 using XTMF.Networking;
@@ -767,8 +768,8 @@ public class ModeChoiceEstimationHost : ITashaRuntime, IDisposable
                 var childAttributes = child.Attributes;
                 if (childAttributes != null)
                 {
-                    current.Start = float.Parse(childAttributes["Start"].InnerText);
-                    current.Stop = float.Parse(childAttributes["Stop"].InnerText);
+                    current.Start = ParseFloat(childAttributes["Start"].InnerText);
+                    current.Stop = ParseFloat(childAttributes["Stop"].InnerText);
                     current.Current = current.Start;
                     if (child.HasChildNodes)
                     {

--- a/Tasha/Scheduler/LocationChoiceCacheMaker.cs
+++ b/Tasha/Scheduler/LocationChoiceCacheMaker.cs
@@ -24,6 +24,7 @@ using System.Text;
 using Datastructure;
 using TMG;
 using XTMF;
+using static TMG.Functions.Utilities;
 // ReSharper disable InconsistentNaming
 // ReSharper disable CompareOfFloatsByEqualityOperator
 
@@ -506,14 +507,14 @@ public class LocationChoiceCacheMaker : ITravelDemandModel
             {
                 for (int j = 0; j <= 6; j++)
                 {
-                    parArray[i, j] = float.Parse(workParams[i][j]);
+                    parArray[i, j] = ParseFloat(workParams[i][j]);
                 }
             }
             else
             {
                 for (int j = 0; j <= 5; j++)
                 {
-                    parArray[i, j] = float.Parse(workParams[i][j]);
+                    parArray[i, j] = ParseFloat(workParams[i][j]);
                 }
             }
         }
@@ -522,18 +523,18 @@ public class LocationChoiceCacheMaker : ITravelDemandModel
 
         for (int j = 0; j < 5; j++)
         {
-            parArray2[0, j] = float.Parse(MAP[j]);
-            parArray2[2, j] = float.Parse(MOP[j]);
+            parArray2[0, j] = ParseFloat(MAP[j]);
+            parArray2[2, j] = ParseFloat(MOP[j]);
         }
 
         for (int j = 0; j < 6; j++)
         {
-            parArray2[1, j] = float.Parse(MBP[j]);
+            parArray2[1, j] = ParseFloat(MBP[j]);
         }
 
         for (int j = 0; j < MMP.Length; j++)
         {
-            parArray2[3, j] = float.Parse(MMP[j]);
+            parArray2[3, j] = ParseFloat(MMP[j]);
         }
 
         parArray2[3, 16] = MMMaxDist1;

--- a/Tasha/Utilities/SaveHouseholdsToCSV.cs
+++ b/Tasha/Utilities/SaveHouseholdsToCSV.cs
@@ -22,6 +22,7 @@ using Tasha.Common;
 using TMG.Input;
 using XTMF;
 using TMG;
+using TMG.Functions;
 
 namespace Tasha.Utilities;
 
@@ -44,8 +45,10 @@ public sealed class SaveHouseholdsToCSV : IPostHousehold, IDisposable
 
     public void Execute(ITashaHousehold household, int iteration)
     {
-        _writer.WriteLine($"{household.HouseholdId},{household.HomeZone.ZoneNumber},{household.ExpansionFactor}," +
-            $"{DwellingTypeToStr(household.DwellingType)},{household.Persons.Length},{household.Vehicles.Length},{household.IncomeClass}");
+        Span<char> buffer = stackalloc char[32];
+        _writer.Write($"{household.HouseholdId},{household.HomeZone.ZoneNumber},");
+        TMG.Functions.Utilities.Write(_writer, household.ExpansionFactor, buffer);
+        _writer.WriteLine($"{DwellingTypeToStr(household.DwellingType)},{household.Persons.Length},{household.Vehicles.Length},{household.IncomeClass}");
     }
 
     private string DwellingTypeToStr(DwellingType dwellingType)


### PR DESCRIPTION
Multi Language Support for floating point numbers
Currently XTMF normally uses the local culture when processing values, but this runs into issues when data might be coming
in from both the local culture and in the standard invariant culture.  These set of sweeping changes strives to
specify which culture to use where appropriate, and if we can't know default to trying the local culture first and then
falling back to the invariant culture as a second option.
