### PR TITLE
Save Parameters as Invariant Culture

### DIFF
--- a/Code/GTAModel/Analysis/CalculateDistanceTravelled.cs
+++ b/Code/GTAModel/Analysis/CalculateDistanceTravelled.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using TMG.Functions;
 using XTMF;
 
 namespace TMG.GTAModel.Analysis;
@@ -168,15 +169,16 @@ public class CalculateDistanceTravelled : ISelfContainedModule
             regionAttractionDistances, regionAttractionSum, regionProductionSum, productionZoneDistances,
             attractionZoneDistances, zoneProductionSum, zoneAttractionSum );
         using StreamWriter writer = new(DistanceTravelledFileName);
+        Span<char> buffer = stackalloc char[32];
         writer.WriteLine("Region Data");
         writer.WriteLine("Region Number,Production Distance Average,Attraction Distance Average");
         for (int i = 0; i < regionProductionDistances.Length; i++)
         {
             writer.Write(regionNumbers[i]);
             writer.Write(',');
-            writer.Write(regionProductionDistances[i]);
+            Utilities.Write(writer, regionProductionDistances[i], buffer);
             writer.Write(',');
-            writer.Write(regionAttractionDistances[i]);
+            Utilities.Write(writer, regionAttractionDistances[i], buffer);
             writer.WriteLine();
         }
         writer.WriteLine();
@@ -189,9 +191,9 @@ public class CalculateDistanceTravelled : ISelfContainedModule
         {
             writer.Write(zones[i].ZoneNumber);
             writer.Write(',');
-            writer.Write(productionZoneDistances[i]);
+            Utilities.Write(writer, productionZoneDistances[i], buffer);
             writer.Write(',');
-            writer.Write(attractionZoneDistances[i]);
+            Utilities.Write(writer, attractionZoneDistances[i], buffer);
             writer.WriteLine();
         }
     }

--- a/Code/GTAModel/Analysis/ExtractWorkers.cs
+++ b/Code/GTAModel/Analysis/ExtractWorkers.cs
@@ -44,6 +44,7 @@ public class ExtractWorkers : ISelfContainedModule
         var flatWorkerData = workerData.GetFlatData();
         using StreamWriter writer = new(OututFile.GetFilePath());
         writer.WriteLine("Zone,PD,Region,EmpStat,Mobility,AgeCat,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatWorkerData.Length; i++)
         {
             foreach (var validI in flatWorkerData[i].ValidIndexes())
@@ -52,19 +53,19 @@ public class ExtractWorkers : ISelfContainedModule
                 {
                     foreach (var validK in flatWorkerData[i].ValidIndexes(validI, validJ))
                     {
-                        writer.Write(flatZones[i].ZoneNumber);
+                        Functions.Utilities.Write(writer, flatZones[i].ZoneNumber, buffer);
                         writer.Write(',');
-                        writer.Write(flatZones[i].PlanningDistrict);
+                        Functions.Utilities.Write(writer, flatZones[i].PlanningDistrict, buffer);
                         writer.Write(',');
-                        writer.Write(flatZones[i].RegionNumber);
+                        Functions.Utilities.Write(writer, flatZones[i].RegionNumber, buffer);
                         writer.Write(',');
-                        writer.Write(validI);
+                        Functions.Utilities.Write(writer, validI, buffer);
                         writer.Write(',');
-                        writer.Write(validJ);
+                        Functions.Utilities.Write(writer, validJ, buffer);
                         writer.Write(',');
-                        writer.Write(validK);
+                        Functions.Utilities.Write(writer, validK, buffer);
                         writer.Write(',');
-                        writer.WriteLine(flatWorkerData[i][validI, validJ, validK]);
+                        Functions.Utilities.WriteLine(writer, flatWorkerData[i][validI, validJ, validK], buffer);
                     }
                 }
             }

--- a/Code/GTAModel/Analysis/OutputAccessStationModel.cs
+++ b/Code/GTAModel/Analysis/OutputAccessStationModel.cs
@@ -20,6 +20,7 @@
 using System;
 using System.IO;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -42,6 +43,7 @@ public sealed class OutputAccessStationModel : ISelfContainedModule
         using var writer = new StreamWriter(OutputFile);
         //output the header
         var validIndex = data.ValidIndexArray();
+        Span<char> buffer = stackalloc char[32];
         writer.WriteLine("Origin,Destination,AccessStation[0],AccessStation[1],AccessStation[2],AccessStation[3],AccessStation[4],Utility[0],Utility[1],Utility[2],Utility[3],Utility[4],Logsum");
         for (int o = 0; o < validIndex.Length; o++)
         {
@@ -67,9 +69,9 @@ public sealed class OutputAccessStationModel : ISelfContainedModule
                 {
                     // make sure this zone is used
                     writer.Write(',');
-                    var ammount = zones[i] == null ? 0.0f : utils[i];
-                    writer.Write(ammount);
-                    total += ammount;
+                    var amount = zones[i] == null ? 0.0f : utils[i];
+                    Utilities.Write(writer, amount, buffer);
+                    total += amount;
                 }
                 writer.Write(',');
                 writer.WriteLine(Math.Log(total));

--- a/Code/GTAModel/Analysis/ReportODSums.cs
+++ b/Code/GTAModel/Analysis/ReportODSums.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -95,20 +96,21 @@ public class ReportODSums : ISelfContainedModule
     private void ProcessDataSource(string dataTag, IDataSource<SparseTwinIndex<float>> dataSource, StreamWriter writer,
         ref double globalIntrazonals, ref double globalSum, ref double globalInternalExternal, ref double globalExternalInternal)
     {
+        Span<char> buffer = stackalloc char[32];
         dataSource.LoadData();
         Sum(dataSource.GiveData().GetFlatData(), out float total, out float intrazonals, out float ie, out float ei);
         dataSource.UnloadData();
         writer.Write( dataTag );
         writer.Write( ',' );
-        writer.Write( total );
+        Utilities.Write(writer, total, buffer); 
         writer.Write( ',' );
-        writer.Write( intrazonals );
+        Utilities.Write(writer, intrazonals, buffer);
         writer.Write( ',' );
-        writer.Write( total - intrazonals );
+        Utilities.Write(writer, total - intrazonals, buffer);
         writer.Write( ',' );
-        writer.Write( ie );
+        Utilities.Write(writer, ie, buffer);
         writer.Write( ',' );
-        writer.WriteLine( ei );
+        Utilities.WriteLine(writer, ei, buffer);
         globalIntrazonals += intrazonals;
         globalSum += total;
         globalInternalExternal += ie;

--- a/Code/GTAModel/Analysis/ValidateAges.cs
+++ b/Code/GTAModel/Analysis/ValidateAges.cs
@@ -38,6 +38,7 @@ public class ValidateAges : ISelfContainedModule
         var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
         var ageRates = Root.Demographics.AgeRates.GetFlatData();
         var ageCategories = Root.Demographics.AgeCategories.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         using ( var writer = new StreamWriter( SaveTo.GetFilePath() ) )
         {
             writer.WriteLine( "Zone,AgeCategory,Persons" );
@@ -48,11 +49,11 @@ public class ValidateAges : ISelfContainedModule
                 var zoneNumber = zones[i].ZoneNumber;
                 for ( int age = 0; age < rates.Length; age++ )
                 {
-                    writer.Write( zoneNumber );
+                    Functions.Utilities.Write(writer, zoneNumber, buffer);
                     writer.Write( ',' );
-                    writer.Write( ageCategories[age] );
+                    Functions.Utilities.Write(writer, ageCategories[age], buffer);
                     writer.Write( ',' );
-                    writer.WriteLine( pop * rates[age] );
+                    Functions.Utilities.WriteLine(writer, pop * rates[age], buffer);
                 }
                 // Update our progress
                 Progress = (float)i / zones.Length;

--- a/Code/GTAModel/Analysis/ValidateDistribution.cs
+++ b/Code/GTAModel/Analysis/ValidateDistribution.cs
@@ -17,12 +17,13 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -334,13 +335,14 @@ public class ValidateDistribution : ISelfContainedModule
             writer.Write(iNumber);
         }
         writer.WriteLine();
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatAggregation.Length; i++)
         {
             writer.Write(getValue(flatAggregation[i]));
             for (int j = 0; j < data[i].Length; j++)
             {
                 writer.Write(',');
-                writer.Write(data[i][j]);
+                Utilities.Write(writer, data[i][j], buffer);
             }
             writer.WriteLine();
         }

--- a/Code/GTAModel/Analysis/ValidateStudents.cs
+++ b/Code/GTAModel/Analysis/ValidateStudents.cs
@@ -41,6 +41,7 @@ public class ValidateStudents : ISelfContainedModule
         var studentRates = Root.Demographics.SchoolRates.GetFlatData();
         var employmentRates = Root.Demographics.EmploymentStatusRates.GetFlatData();
         var employmentCategories = Root.Demographics.EmploymentStatus.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         using ( var writer = new StreamWriter( SaveTo.GetFilePath() ) )
         {
             writer.WriteLine( "Zone,AgeCategory,EmpStat,Persons" );
@@ -57,13 +58,13 @@ public class ValidateStudents : ISelfContainedModule
                     var stuEmpRate = studentRate[age];
                     for ( int emp = 0; emp < stuEmpRate.Length; emp++ )
                     {
-                        writer.Write( zoneNumber );
+                        Functions.Utilities.Write(writer, zoneNumber, buffer);
                         writer.Write( ',' );
-                        writer.Write( ageCategories[age] );
+                        Functions.Utilities.Write(writer, ageCategories[age], buffer);
                         writer.Write( ',' );
-                        writer.Write( employmentCategories[emp] );
+                        Functions.Utilities.Write(writer, employmentCategories[emp], buffer);
                         writer.Write( ',' );
-                        writer.WriteLine( stuEmpRate[emp] * agePop * empRate[age][emp] );
+                        Functions.Utilities.WriteLine(writer, stuEmpRate[emp] * agePop * empRate[age][emp], buffer);
                     }
                 }
                 // Update our progress

--- a/Code/GTAModel/Analysis/ValidateStudentsGeneration.cs
+++ b/Code/GTAModel/Analysis/ValidateStudentsGeneration.cs
@@ -52,6 +52,7 @@ public class ValidateStudentsGeneration : ISelfContainedModule
         var employmentCategories = Root.Demographics.EmploymentStatus.GetFlatData();
         var dailyRates = LoadDailyRates.GiveData();
         var timeOfDayRates = LoadTimeOfDayRates.GiveData();
+        Span<char> buffer = stackalloc char[32];
         using ( var writer = new StreamWriter( SaveTo.GetFilePath() ) )
         {
             writer.WriteLine( "Zone,AgeCategory,EmpStat,Persons" );
@@ -70,13 +71,13 @@ public class ValidateStudentsGeneration : ISelfContainedModule
                     var generationRate = dailyRates[pd, age, 0] * timeOfDayRates[pd, age, 0];
                     for ( int emp = 0; emp < stuEmpRate.Length; emp++ )
                     {
-                        writer.Write( zoneNumber );
+                        Functions.Utilities.Write(writer, zoneNumber, buffer);
                         writer.Write( ',' );
-                        writer.Write( ageCategories[age] );
+                        Functions.Utilities.Write(writer, ageCategories[age], buffer);
                         writer.Write( ',' );
-                        writer.Write( employmentCategories[emp] );
+                        Functions.Utilities.Write(writer, employmentCategories[emp], buffer);
                         writer.Write( ',' );
-                        writer.WriteLine( stuEmpRate[emp] * agePop * empRate[age][emp] * generationRate);
+                        Functions.Utilities.WriteLine(writer, stuEmpRate[emp] * agePop * empRate[age][emp] * generationRate, buffer);
                     }
                 }
                 // Update our progress

--- a/Code/GTAModel/DataUtility/FloatList.cs
+++ b/Code/GTAModel/DataUtility/FloatList.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace TMG.GTAModel.DataUtility;
@@ -213,9 +214,9 @@ public class FloatList : IList<float>
     public override string ToString()
     {
         var builder = new StringBuilder();
-        for ( var i = 0; i < Values.Length; i++ )
+        for ( var i = 0; i < Values.Length; i++)
         {
-            builder.Append( Values[i] );
+            builder.Append(CultureInfo.InvariantCulture, $"{Values[i]}");
             builder.Append( ',' );
         }
         return builder.ToString( 0, builder.Length - 1 );

--- a/Code/GTAModel/Distribution/BlendedDemographicCategoryLogsumDistribution.cs
+++ b/Code/GTAModel/Distribution/BlendedDemographicCategoryLogsumDistribution.cs
@@ -592,12 +592,13 @@ public class BlendedDemographicCategoryLogsumDistribution : IDemographicDistribu
         }
         var startOfLine = Root.CurrentIteration + "," + CurrentMultiSetIndex + ",";
         var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < attraction.Length; i++)
         {
             writer.Write(startOfLine);
-            writer.Write(zones[i].ZoneNumber);
+            Utilities.Write(writer, zones[i].ZoneNumber, buffer);
             writer.Write(',');
-            writer.WriteLine(attraction[i]);
+            Utilities.WriteLine(writer, attraction[i], buffer);
         }
     }
 

--- a/Code/GTAModel/GTAPopulation.cs
+++ b/Code/GTAModel/GTAPopulation.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -233,7 +234,7 @@ public class GTAPopulation : IPopulation
                     builder.Append( ',' );
                     builder.Append( person.DriversLicense ? 1 : 0 );
                     builder.Append( ',' );
-                    builder.Append( person.ExpansionFactor );
+                    builder.Append(CultureInfo.InvariantCulture, $"{person.ExpansionFactor}");
                     builder.AppendLine();
                 }
                 flatOutput[i] = builder;

--- a/Code/GTAModel/Generation/HBOGeneration.cs
+++ b/Code/GTAModel/Generation/HBOGeneration.cs
@@ -171,6 +171,7 @@ public class HBOGeneration : DemographicCategoryGeneration
             {
                 writer.WriteLine("Age,Employment,Occupation,Mobility,Total");
             }
+            Span<char> buffer = stackalloc char[32];
             writer.Write(AgeCategoryRange.ToString());
             writer.Write(',');
             writer.Write(EmploymentStatusCategory.ToString());
@@ -179,7 +180,7 @@ public class HBOGeneration : DemographicCategoryGeneration
             writer.Write(',');
             writer.Write(Mobility.ToString());
             writer.Write(',');
-            writer.WriteLine(totalProduction);
+            Functions.Utilities.WriteLine(writer, totalProduction, buffer);
         }
     }
 }

--- a/Code/GTAModel/Generation/PoRPoSGeneration.cs
+++ b/Code/GTAModel/Generation/PoRPoSGeneration.cs
@@ -233,6 +233,7 @@ public class PoRPoSGeneration : DemographicCategoryGeneration
             {
                 writer.WriteLine("Age,Employment,Occupation,Mobility,Total");
             }
+            Span<char> buffer = stackalloc char[32];
             writer.Write(AgeCategoryRange.ToString());
             writer.Write(',');
             writer.Write(EmploymentStatusCategory.ToString());
@@ -241,7 +242,7 @@ public class PoRPoSGeneration : DemographicCategoryGeneration
             writer.Write(',');
             writer.Write(Mobility.ToString());
             writer.Write(',');
-            writer.WriteLine(totalProduction);
+            Functions.Utilities.WriteLine(writer, totalProduction, buffer);
         }
     }
 }

--- a/Code/GTAModel/Generation/PoRPoWGeneration.cs
+++ b/Code/GTAModel/Generation/PoRPoWGeneration.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 // ReSharper disable CompareOfFloatsByEqualityOperator
@@ -293,11 +294,12 @@ public class PoRPoWGeneration : DemographicCategoryGeneration
             // if we are the first thing to generate, then write the header as well
             writer.WriteLine("Zone,Age,Employment,Occupation,Mobility,Attraction");
         }
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatAttractions.Length; i++)
         {
             writer.Write(attractions.GetSparseIndex(i));
             writer.Write(categoryData);
-            writer.WriteLine(flatAttractions[i]);
+            Utilities.WriteLine(writer, flatAttractions[i], buffer);
         }
     }
 
@@ -318,6 +320,7 @@ public class PoRPoWGeneration : DemographicCategoryGeneration
             {
                 writer.WriteLine("Age,Employment,Occupation,Mobility,Production,Attraction,WAH");
             }
+            Span<char> buffer = stackalloc char[32];
             writer.Write(AgeCategoryRange.ToString());
             writer.Write(',');
             writer.Write(EmploymentStatusCategory.ToString());
@@ -326,11 +329,11 @@ public class PoRPoWGeneration : DemographicCategoryGeneration
             writer.Write(',');
             writer.Write(Mobility.ToString());
             writer.Write(',');
-            writer.Write(totalProduction);
+            Utilities.Write(writer, totalProduction, buffer);
             writer.Write(',');
-            writer.Write(totalAttraction);
+            Utilities.Write(writer, totalAttraction, buffer);
             writer.Write(',');
-            writer.WriteLine(WorkAtHomeTotal);
+            Utilities.WriteLine(writer, WorkAtHomeTotal, buffer);
         }
     }
 }

--- a/Code/GTAModel/NestedModeSplit.cs
+++ b/Code/GTAModel/NestedModeSplit.cs
@@ -189,6 +189,7 @@ public class NestedModeSplit : IInteractiveModeSplit
         {
             if ( split.Result != null )
             {
+                Span<char> buffer = stackalloc char[32];
                 using StreamWriter writer = new(Path.Combine(directoryName, modeNode.ModeName + ".csv"));
                 var header = true;
                 var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
@@ -210,7 +211,7 @@ public class NestedModeSplit : IInteractiveModeSplit
                     for (int j = 0; j < zones.Length; j++)
                     {
                         writer.Write(',');
-                        writer.Write(data[i * zones.Length + j]);
+                        Utilities.Write(writer, data[i * zones.Length + j], buffer);
                     }
                     writer.WriteLine();
                 }

--- a/Code/GTAModel/PopulationValidation.cs
+++ b/Code/GTAModel/PopulationValidation.cs
@@ -17,13 +17,15 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Datastructure;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.Marshalling;
 using System.Threading.Tasks;
-using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 using Range = Datastructure.Range;
@@ -184,6 +186,7 @@ public class PopulationValidation : ITravelDemandModel
             writer.Write(Demographics.EmploymentStatus[emp]);
         }
         writer.WriteLine("Population");
+        Span<char> buffer = stackalloc char[32];
         foreach (var zone in zoneArray.ValidIndexies())
         {
             var data = employmentStatusDist[zone];
@@ -209,10 +212,10 @@ public class PopulationValidation : ITravelDemandModel
                     }
                     res -= Demographics.EmploymentStatusRates[zone][validAges[ageCat], validEmploymentStatus[e]];
                     writer.Write(',');
-                    writer.Write(res * population);
+                    Utilities.Write(writer, res * population, buffer);
                 }
                 writer.Write(',');
-                writer.WriteLine(population);
+                Utilities.WriteLine(writer, population, buffer);
             }
         }
     }
@@ -307,6 +310,7 @@ public class PopulationValidation : ITravelDemandModel
             writer.Write(Demographics.AgeCategories[ageCat]);
         }
         writer.WriteLine(",Synthetic Population, Given Population");
+        Span<char> buffer = stackalloc char[32];
         foreach (var zone in zoneArray.ValidIndexies())
         {
             var total = 0f;
@@ -321,17 +325,18 @@ public class PopulationValidation : ITravelDemandModel
             for (int a = 0; a < agesLength; a++)
             {
                 writer.Write(',');
-                writer.Write((zoneDist[validAges[a]]) - Demographics.AgeRates[zone, validAges[a]] * population);
+                Utilities.Write(writer, (zoneDist[validAges[a]]) - Demographics.AgeRates[zone, validAges[a]] * population, buffer);
             }
             writer.Write(',');
-            writer.Write(total);
+            Utilities.Write(writer, total, buffer);
             writer.Write(',');
-            writer.WriteLine(zoneArray[zone].Population);
+            Utilities.WriteLine(writer, zoneArray[zone].Population, buffer);
         }
     }
 
     private void ValidateDriversLicense()
     {
+        Span<char> buffer = stackalloc char[32];
         if (!DriversLicenseReportFile.ContainsFileName()) return;
         var zones = ZoneSystem.ZoneArray.GetFlatData();
         var numberOfLicenses = new float[zones.Length];
@@ -343,11 +348,11 @@ public class PopulationValidation : ITravelDemandModel
         {
             writer.Write(zones[i].ZoneNumber);
             writer.Write(',');
-            writer.Write(expectedNumberOfLicenses[i]);
+            Utilities.Write(writer, expectedNumberOfLicenses[i], buffer);
             writer.Write(',');
-            writer.Write(numberOfLicenses[i]);
+            Utilities.Write(writer, numberOfLicenses[i], buffer);
             writer.Write(',');
-            writer.Write(expectedNumberOfLicenses[i] - numberOfLicenses[i]);
+            Utilities.Write(writer, expectedNumberOfLicenses[i] - numberOfLicenses[i], buffer);
             writer.WriteLine();
         }
     }
@@ -399,6 +404,7 @@ public class PopulationValidation : ITravelDemandModel
             writer.Write(',');
         }
         writer.WriteLine("Population");
+        Span<char> buffer = stackalloc char[32];
         foreach (var employmentStatus in Demographics.EmploymentStatus.ValidIndexies())
         {
             if (employmentStatus == UnemployedEmploymentStatus) continue;
@@ -433,16 +439,16 @@ public class PopulationValidation : ITravelDemandModel
                             writer.Write(',');
                             writer.Write(employmentStatus);
                             writer.Write(',');
-                            writer.Write(result * population);
+                            Utilities.Write(writer, result * population, buffer);
                         }
                         else
                         {
                             writer.Write(',');
-                            writer.Write(result * population);
+                            Utilities.Write(writer, result * population, buffer);
                         }
                     }
                     writer.Write(',');
-                    writer.WriteLine(population);
+                    Utilities.WriteLine(writer, population, buffer);
                 }
             }
         }

--- a/Code/GTAModel/Purpose/InversedPurpose.cs
+++ b/Code/GTAModel/Purpose/InversedPurpose.cs
@@ -190,6 +190,7 @@ public class InversedPurpose : IPurpose
             using StreamWriter writer = new(Path.Combine(directoryName, modeNode.ModeName + ".csv"));
             var header = true;
             var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < zones.Length; i++)
             {
                 if (header)
@@ -208,7 +209,7 @@ public class InversedPurpose : IPurpose
                 for (int j = 0; j < zones.Length; j++)
                 {
                     writer.Write(',');
-                    writer.Write(row == null ? 0 : row[j]);
+                    Utilities.Write(writer, row == null ? 0 : row[j], buffer);
                 }
                 writer.WriteLine();
             }

--- a/Code/GTAModel/V2/Generation/PoRPoWGeneration.cs
+++ b/Code/GTAModel/V2/Generation/PoRPoWGeneration.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 // ReSharper disable InconsistentNaming
@@ -331,13 +332,15 @@ public class PoRPoWGeneration : DemographicCategoryGeneration
             // if we are the first thing to generate, then write the header as well
             writer.WriteLine("Zone,Age,Employment,Occupation,Production,Attraction");
         }
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < flatAttractions.Length; i++)
         {
             writer.Write(attractions.GetSparseIndex(i));
             writer.Write(categoryData);
-            writer.Write(flatProduction[i]);
             writer.Write(',');
-            writer.WriteLine(flatAttractions[i]);
+            Utilities.Write(writer, flatProduction[i], buffer);
+            writer.Write(',');
+            Utilities.WriteLine(writer, flatAttractions[i], buffer);
         }
     }
 
@@ -358,19 +361,20 @@ public class PoRPoWGeneration : DemographicCategoryGeneration
             {
                 writer.WriteLine("Age,Employment,Occupation,Production,Attraction,WAH,IntraZonal");
             }
+            Span<char> buffer = stackalloc char[32];
             writer.Write(AgeCategoryRange.ToString());
             writer.Write(',');
             writer.Write(EmploymentStatusCategory.ToString());
             writer.Write(',');
             writer.Write(OccupationCategory.ToString());
             writer.Write(',');
-            writer.Write(totalProduction);
+            Utilities.Write(writer, totalProduction, buffer);
             writer.Write(',');
-            writer.Write(totalAttraction);
+            Utilities.Write(writer, totalAttraction, buffer);
             writer.Write(',');
-            writer.Write(WorkAtHomeTotal);
+            Utilities.Write(writer, WorkAtHomeTotal, buffer);
             writer.Write(',');
-            writer.WriteLine(WorkIntrazonalTotal);
+            Utilities.WriteLine(writer, WorkIntrazonalTotal, buffer);
         }
     }
 }

--- a/Code/GTAModel/V2/Generation/SchoolGeneration.cs
+++ b/Code/GTAModel/V2/Generation/SchoolGeneration.cs
@@ -20,6 +20,7 @@
 using System;
 using System.IO;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -108,15 +109,14 @@ public class SchoolGeneration : IDemographicCategoryGeneration
             {
                 writer.WriteLine("Age,Zone,Production");
             }
-
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < zones.Length; i++)
             {
                 writer.Write(Age);
                 writer.Write(',');
                 writer.Write(zones[i].ZoneNumber);
                 writer.Write(',');
-                writer.Write(prod[i]);
-                writer.WriteLine();
+                Utilities.WriteLine(writer, prod[i], buffer);
             }
         }
     }

--- a/Code/NetworkEstimation/CalcRMSEofBoardingsAMPMWAW.cs
+++ b/Code/NetworkEstimation/CalcRMSEofBoardingsAMPMWAW.cs
@@ -220,11 +220,12 @@ public class CalcRMSEofBoardingsAMPMWAW : IEmmeTool
     {
         using StreamWriter writer = new(location);
         writer.WriteLine("Line,Boardings");
+        Span<char> buffer = stackalloc char[32];
         foreach (var set in periodData)
         {
             writer.Write(set.Key);
             writer.Write(',');
-            writer.WriteLine(set.Value);
+            Functions.Utilities.WriteLine(writer, set.Value, buffer);
         }
     }
 

--- a/Code/NetworkEstimation/GeneticNetworkEstimationClient.cs
+++ b/Code/NetworkEstimation/GeneticNetworkEstimationClient.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using TMG.Emme;
+using TMG.Functions;
 using XTMF;
 using XTMF.Networking;
 
@@ -302,16 +303,17 @@ public class GeneticNetworkEstimationClient : I4StepModel
     {
         using StreamWriter writer = new("LineSummery" + (SummeryNumber++) + ".csv");
         writer.WriteLine("Truth,Predicted,Error,Error^2,EmmeLines");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < aggToTruth.Length; i++)
         {
             float error = aggToTruth[i] - Truth[i].Bordings;
-            writer.Write(Truth[i].Bordings);
+            Utilities.Write(writer, Truth[i].Bordings, buffer);
             writer.Write(',');
-            writer.Write(aggToTruth[i]);
+            Utilities.Write(writer, aggToTruth[i], buffer);
             writer.Write(',');
-            writer.Write(error);
+            Utilities.Write(writer, error, buffer);
             writer.Write(',');
-            writer.Write(error * error);
+            Utilities.Write(writer, error * error, buffer);
             for (int j = 0; j < Truth[i].Id.Length; j++)
             {
                 writer.Write(',');
@@ -324,7 +326,7 @@ public class GeneticNetworkEstimationClient : I4StepModel
         writer.WriteLine("Orphans");
         foreach (var orphan in orphans)
         {
-            writer.Write(orphan.Value);
+            Utilities.Write(writer, orphan.Value, buffer);
             writer.Write(',');
             writer.WriteLine(orphan.Key);
         }

--- a/Code/NetworkEstimation/NetworkAI.cs
+++ b/Code/NetworkEstimation/NetworkAI.cs
@@ -23,6 +23,7 @@ using System.Globalization;
 using System.IO;
 using System.Xml;
 using TMG.Emme;
+using TMG.Functions;
 using XTMF;
 
 namespace TMG.NetworkEstimation;
@@ -251,11 +252,12 @@ public class NetworkAi : INetworkEstimationAI
             ParameterVolatility[i] = absmeandiff;
         }
         using StreamWriter writer = new("Volatility.csv", true);
-        writer.Write(ParameterVolatility[0]);
+        Span<char> buffer = stackalloc char[32];
+        Utilities.Write(writer, ParameterVolatility[0], buffer);
         for (int i = 1; i < dimensions; i++)
         {
             writer.Write(',');
-            writer.Write(ParameterVolatility[i]);
+            Utilities.Write(writer, ParameterVolatility[i], buffer);
         }
         writer.WriteLine();
     }

--- a/Code/NetworkEstimation/NetworkEstimationServer.cs
+++ b/Code/NetworkEstimation/NetworkEstimationServer.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using TMG.Functions;
 using XTMF;
 using XTMF.Networking;
 
@@ -141,14 +142,15 @@ public class NetworkEstimationServer : IModelSystemTemplate
             var set = result as float[];
             if ( set == null || set.Length == 0 ) return;
             var length = set.Length;
+            Span<char> buffer = stackalloc char[32];
             lock ( this )
             {
                 using StreamWriter writer = new(ParameterEvaluationFile, true);
-                writer.Write(set[0]);
+                Utilities.Write(writer, set[0], buffer);
                 for (int i = 0; i < length; i++)
                 {
                     writer.Write(',');
-                    writer.Write(set[i]);
+                    Utilities.Write(writer, set[i], buffer);
                 }
                 writer.WriteLine();
             }

--- a/Code/NetworkEstimation/NetworkEstimationTemplate.cs
+++ b/Code/NetworkEstimation/NetworkEstimationTemplate.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using TMG.Emme;
+using TMG.Functions;
 using XTMF;
 using XTMF.Networking;
 
@@ -304,20 +305,21 @@ public class NetworkEstimationTemplate : I4StepModel
         Parameters = [.. parameters];
     }
 
-    private void PrintSummery(float[] aggToTruth, List<KeyValuePair<string, float>> orphans)
+    private void PrintSummary(float[] aggToTruth, List<KeyValuePair<string, float>> orphans)
     {
         using StreamWriter writer = new("LineSummery" + (SummeryNumber++) + ".csv");
         writer.WriteLine("Truth,Predicted,Error,Error^2,EmmeLines");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < aggToTruth.Length; i++)
         {
             float error = aggToTruth[i] - Truth[i].Bordings;
-            writer.Write(Truth[i].Bordings);
+            Utilities.Write(writer, Truth[i].Bordings, buffer);
             writer.Write(',');
-            writer.Write(aggToTruth[i]);
+            Utilities.Write(writer, aggToTruth[i], buffer);
             writer.Write(',');
-            writer.Write(error);
+            Utilities.Write(writer, error, buffer);
             writer.Write(',');
-            writer.Write(error * error);
+            Utilities.Write(writer, error * error, buffer);
             for (int j = 0; j < Truth[i].Id.Length; j++)
             {
                 writer.Write(',');
@@ -330,7 +332,7 @@ public class NetworkEstimationTemplate : I4StepModel
         writer.WriteLine("Orphans");
         foreach (var orphan in orphans)
         {
-            writer.Write(orphan.Value);
+            Utilities.Write(writer, orphan.Value, buffer);
             writer.Write(',');
             writer.WriteLine(orphan.Key);
         }
@@ -393,7 +395,7 @@ public class NetworkEstimationTemplate : I4StepModel
     private void SaveBordingData(float[] aggToTruth, List<KeyValuePair<string, float>> orphans)
     {
         File.Copy(MacroOutputFile, "Best-" + Path.GetFileName(MacroOutputFile), true);
-        PrintSummery(aggToTruth, orphans);
+        PrintSummary(aggToTruth, orphans);
     }
 
     private void SaveEvaluation(ParameterSetting[] param, float value, double rmse, double mabs, double terror)
@@ -436,20 +438,21 @@ public class NetworkEstimationTemplate : I4StepModel
             writer.WriteLine();
         }
         FirstRun = false;
-        writer.Write(param[0].Current);
+        Span<char> buffer = stackalloc char[64];
+        Utilities.Write(writer, param[0].Current, buffer);
         for (int i = 1; i < param.Length; i++)
         {
             writer.Write(',');
-            writer.Write(param[i].Current);
+            Utilities.Write(writer, param[i].Current, buffer);
         }
         writer.Write(',');
-        writer.Write(value);
+        Utilities.Write(writer, value, buffer);
         writer.Write(',');
-        writer.Write(rmse);
+        Utilities.Write(writer, rmse, buffer);
         writer.Write(',');
-        writer.Write(mabs);
+        Utilities.Write(writer, mabs, buffer);
         writer.Write(',');
-        writer.WriteLine(terror);
+        Utilities.WriteLine(writer, terror, buffer);
     }
 
     private void SetupInputFiles(ParameterSetting[] param)
@@ -461,10 +464,12 @@ public class NetworkEstimationTemplate : I4StepModel
          */
         using StreamWriter writer = new(MacroInputFile);
         writer.WriteLine("t matrices");
+        Span<char> buffer = stackalloc char[32];
         foreach (var p in param)
         {
             writer.WriteLine($"m ms{p.MsNumber} {p.ParameterName}");
-            writer.WriteLine($" all all: {p.Current}");
+            writer.Write($" all all: ");
+            Utilities.WriteLine(writer, p.Current, buffer);
         }
     }
 }

--- a/Code/NetworkEstimation/RegionErrorTally.cs
+++ b/Code/NetworkEstimation/RegionErrorTally.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.IO;
 using Datastructure;
 using TMG.Emme;
+using TMG.Functions;
 using XTMF;
 using static System.String;
 
@@ -157,19 +158,20 @@ public class RegionErrorTally : IErrorTally
                     }
                 }
             }
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < numberOfModesFirstLetters; i++)
             {
                 if (RegionPercentError)
                 {
-                    writer.Write(Math.Abs(aggPredToMode[i] - aggTtsToMode[i]) / aggTtsToMode[i]);
+                    Utilities.Write(writer, Math.Abs(aggPredToMode[i] - aggTtsToMode[i]) / aggTtsToMode[i], buffer);
                 }
                 else
                 {
-                    writer.Write(aggPredToMode[i] - aggTtsToMode[i]);
+                    Utilities.Write(writer, aggPredToMode[i] - aggTtsToMode[i], buffer);
                 }
                 writer.Write(',');
             }
-            writer.WriteLine(finalError);
+            Utilities.WriteLine(writer, finalError, buffer);
         }
         return finalError;
     }

--- a/Code/NetworkEstimation/V4ClienntEstimationSupplementalReport1.cs
+++ b/Code/NetworkEstimation/V4ClienntEstimationSupplementalReport1.cs
@@ -38,12 +38,12 @@ public class V4ClienntEstimationSupplementalReport1 : ClientFileAggregation, IEm
         foreach (var f in modelResults)
         {
             builder.Append(',');
-            builder.Append(f);
+            builder.Append(CultureInfo.InvariantCulture, $"{f}");
         }
         foreach (var val in Root.CurrentTask.ParameterValues)
         {
             builder.Append(',');
-            builder.Append(val.ToString(CultureInfo.InvariantCulture));
+            builder.Append(CultureInfo.InvariantCulture, $"{val}");
         }
         builder.AppendLine();
 

--- a/Code/TMG.Emme/Analysis/MatrixAnalysis.cs
+++ b/Code/TMG.Emme/Analysis/MatrixAnalysis.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -47,8 +48,8 @@ public sealed class MatrixAnalysis : IEmmeTool, ISelfContainedModule
 
     private void SaveData(float[][] aggData, string[] aggregationHeaders)
     {
-
         using StreamWriter writer = new(OutputFile);
+        Span<char> buffer = stackalloc char[32];
         if (ThirdNormalizedForm)
         {
             writer.WriteLine("From,To,Value");
@@ -57,11 +58,11 @@ public sealed class MatrixAnalysis : IEmmeTool, ISelfContainedModule
                 var row = aggData[i];
                 for (int j = 0; j < aggregationHeaders.Length; j++)
                 {
-                    writer.Write(aggregationHeaders[i]);
+                    Functions.Utilities.Write(writer, aggregationHeaders[i], buffer);
                     writer.Write(',');
-                    writer.Write(aggregationHeaders[j]);
+                    Functions.Utilities.Write(writer, aggregationHeaders[j], buffer);
                     writer.Write(',');
-                    writer.WriteLine(row[j]);
+                    Functions.Utilities.WriteLine(writer, row[j], buffer);
                 }
             }
         }
@@ -81,14 +82,15 @@ public sealed class MatrixAnalysis : IEmmeTool, ISelfContainedModule
             writer.Write(aggregationHeaders[i]);
         }
         writer.WriteLine();
-        for(int i = 0; i < aggregationHeaders.Length; i++)
+        Span<char> buffer = stackalloc char[32];
+        for (int i = 0; i < aggregationHeaders.Length; i++)
         {
             writer.Write(aggregationHeaders[i]);
             var row = aggData[i];
             for(int j = 0; j < row.Length; j++)
             {
                 writer.Write(',');
-                writer.Write(row[j]);
+                TMG.Functions.Utilities.Write(writer, row[j], buffer);
             }
             writer.WriteLine();
         }

--- a/Code/TMG.Emme/Utilities/LOSBetweenPoints.cs
+++ b/Code/TMG.Emme/Utilities/LOSBetweenPoints.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 namespace TMG.Emme.Utilities;
@@ -119,6 +120,7 @@ public class LOSBetweenPoints : IEmmeTool
 
         internal void SaveResults(List<int> nodesToExplore)
         {
+            Span<char> buffer = stackalloc char[32];
             using (var writer = new StreamWriter(SaveTo))
             {
                 writer.Write("Origin\\Destination");
@@ -134,7 +136,7 @@ public class LOSBetweenPoints : IEmmeTool
                     for (int j = 0; j < Data[i].Length; j++)
                     {
                         writer.Write(',');
-                        writer.Write(Data[i][j]);
+                        Functions.Utilities.Write(writer, Data[i][j], buffer);
                     }
                     writer.WriteLine();
                 }

--- a/Code/TMG.Estimation/AI/GenerateParameterStatistics.cs
+++ b/Code/TMG.Estimation/AI/GenerateParameterStatistics.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 namespace TMG.Estimation.AI;
@@ -181,19 +182,20 @@ public class GenerateParameterStatistics : IEstimationAI
         var baseRho = GetRho(baseValue, zeroValue);
         using var writer = new StreamWriter(ReportFile);
         writer.WriteLine("ParameterName,Coefficient,Fitness,Rho^2,DeltaRho^2");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 2; i < jobs.Count; i++)
         {
             var withoutParameterValue = jobs[i].Value;
             var rho = GetRho(withoutParameterValue, zeroValue);
             writer.Write(parameters[i - 2].Names[0]);
             writer.Write(',');
-            writer.Write(jobs[1].Parameters[i - 2].Current);
+            Functions.Utilities.Write(writer, jobs[1].Parameters[i - 2].Current, buffer);
             writer.Write(',');
-            writer.Write(withoutParameterValue);
+            Functions.Utilities.Write(writer, withoutParameterValue, buffer);
             writer.Write(',');
-            writer.Write(rho);
+            Functions.Utilities.Write(writer, rho, buffer);
             writer.Write(',');
-            writer.WriteLine(rho - baseRho);
+            Functions.Utilities.WriteLine(writer, rho - baseRho, buffer);
         }
     }
 

--- a/Code/TMG.Estimation/AI/GenerateParameterTStatistics.cs
+++ b/Code/TMG.Estimation/AI/GenerateParameterTStatistics.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Datastructure;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 namespace TMG.Estimation.AI;
@@ -187,12 +188,13 @@ public class GenerateParameterTStatistics : IEstimationAI
         var zeroValue = jobs[0].Value;
         var baseValue = jobs[1].Value;
         using var writer = new StreamWriter(ReportFile);
+        Span<char> buffer = stackalloc char[32];
         writer.WriteLine("Fitness,ZeroFitness,Rho^2");
-        writer.Write(baseValue);
+        Functions.Utilities.Write(writer, baseValue, buffer);
         writer.Write(',');
-        writer.Write(zeroValue);
+        Functions.Utilities.Write(writer, zeroValue, buffer);
         writer.Write(',');
-        writer.WriteLine(GetRho(baseValue, zeroValue));
+        Functions.Utilities.WriteLine(writer, GetRho(baseValue, zeroValue), buffer);
         writer.WriteLine("ParameterName,Coefficient,LeftCoefficient,RightCoefficient,LeftFitness,RightFitness,SecondDerivative,t-statistic");
         for (int i = 0; i < parameters.Count; i++)
         {
@@ -203,19 +205,19 @@ public class GenerateParameterTStatistics : IEstimationAI
             writer.Write(parameters[i].Names[0]);
             writer.Write('"');
             writer.Write(',');
-            writer.Write(current);
+            Functions.Utilities.Write(writer, current, buffer);
             writer.Write(',');
-            writer.Write(jobs[offset].Parameters[i].Current);
+            Functions.Utilities.Write(writer, jobs[offset].Parameters[i].Current, buffer);
             writer.Write(',');
-            writer.Write(jobs[offset + 1].Parameters[i].Current);
+            Functions.Utilities.Write(writer, jobs[offset + 1].Parameters[i].Current, buffer);
             writer.Write(',');
-            writer.Write(jobs[offset].Value);
+            Functions.Utilities.Write(writer, jobs[offset].Value, buffer);
             writer.Write(',');
-            writer.Write(jobs[offset + 1].Value);
+            Functions.Utilities.Write(writer, jobs[offset + 1].Value, buffer);
             writer.Write(',');
-            writer.Write(secondDerivative);
+            Functions.Utilities.Write(writer, secondDerivative, buffer);
             writer.Write(',');
-            writer.WriteLine(ComputeTStatistic(current, secondDerivative));
+            Functions.Utilities.WriteLine(writer, ComputeTStatistic(current, secondDerivative), buffer);
         }
     }
 

--- a/Code/TMG.Estimation/AI/GravityOptimization.cs
+++ b/Code/TMG.Estimation/AI/GravityOptimization.cs
@@ -221,6 +221,7 @@ public class GravityOptimization : IEstimationAI
         var generation = Root.CurrentIteration;
         var exists = File.Exists(StarLog);
         using StreamWriter writer = new(StarLog, true);
+        Span<char> buffer = stackalloc char[32];
         if (!exists)
         {
             writer.Write("Generation,Star,Mass");
@@ -240,14 +241,14 @@ public class GravityOptimization : IEstimationAI
             writer.Write(',');
             writer.Write(Stars[i].StarNumber);
             writer.Write(',');
-            writer.Write(Stars[i].CurrentMass);
+            Functions.Utilities.Write(writer, Stars[i].CurrentMass, buffer);
             var position = Stars[i].Position;
             for (int j = 0; j < position.Length; j++)
             {
                 for (int k = 0; k < Parameters[j].Names.Length; k++)
                 {
                     writer.Write(',');
-                    writer.Write(Stars[i].Position[j]);
+                    Functions.Utilities.Write(writer, position[j], buffer);
                 }
             }
             writer.WriteLine();

--- a/Code/TMG.Estimation/EstimationHost.cs
+++ b/Code/TMG.Estimation/EstimationHost.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -419,14 +420,14 @@ public sealed class EstimationHost : IEstimationHost, IDisposable
         StringBuilder toWrite = new();
         toWrite.Append( CurrentIteration );
         toWrite.Append( ',' );
-        toWrite.Append( currentJob.Value );
+        toWrite.Append(CultureInfo.InvariantCulture, $"{currentJob.Value}");
         for ( int i = 0; i < currentJob.Parameters.Length; i++ )
         {
             for ( int j = 0; j < Parameters[i].Names.Length; j++ )
             {
                 toWrite.Append( ',' );
                 // this uses the i th value since they are all the same
-                toWrite.Append( currentJob.Parameters[i].Current );
+                toWrite.Append(CultureInfo.InvariantCulture, $"{currentJob.Parameters[i].Current}");
             }
         }
         while ( true )

--- a/Code/TMG.Estimation/LocalEstimationHost.cs
+++ b/Code/TMG.Estimation/LocalEstimationHost.cs
@@ -18,8 +18,10 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
+using TMG.Functions;
 using TMG.Input;
 using XTMF;
 
@@ -123,6 +125,7 @@ public class LocalEstimationHost : IEstimationHost
 
     private void SaveResultsToDisk()
     {
+        Span<char> buffer = stackalloc char[32];
         while (true)
         {
             try
@@ -150,14 +153,14 @@ public class LocalEstimationHost : IEstimationHost
                     var currentJob = CurrentJobs[i];
                     writer.Write(CurrentIteration);
                     writer.Write(',');
-                    writer.Write(currentJob.Value);
+                    TMG.Functions.Utilities.Write(writer, currentJob.Value, buffer);
                     for (int j = 0; j < currentJob.Parameters.Length; j++)
                     {
                         for (int k = 0; k < Parameters[j].Names.Length; k++)
                         {
                             writer.Write(',');
                             // this uses the i th value since they are all the same
-                            writer.Write(currentJob.Parameters[j].Current);
+                            TMG.Functions.Utilities.Write(writer, currentJob.Parameters[j].Current, buffer);
                         }
                     }
                     writer.WriteLine();

--- a/Code/TMG.Estimation/Utilities/GetBestParameters.cs
+++ b/Code/TMG.Estimation/Utilities/GetBestParameters.cs
@@ -77,17 +77,18 @@ public class GetBestParameters : ISelfContainedModule
             }
         }
         writer.WriteLine();
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < best.Length; i++)
         {
             writer.Write(best[i].Generation);
             writer.Write(',');
-            writer.Write(best[i].Job.Value);
+            Functions.Utilities.Write(writer, best[i].Job.Value, buffer);
             for (int j = 0; j < best[i].Job.Parameters.Length; j++)
             {
                 for (int k = 0; k < best[i].Job.Parameters[j].Names.Length; k++)
                 {
                     writer.Write(',');
-                    writer.Write(best[i].Job.Parameters[j].Current);
+                    Functions.Utilities.Write(writer, best[i].Job.Parameters[j].Current, buffer);
                 }
             }
             writer.WriteLine();

--- a/Code/TMG.Functions/SaveData.cs
+++ b/Code/TMG.Functions/SaveData.cs
@@ -79,7 +79,7 @@ public static class SaveData
                         for (int j = 0; j < zones.Length; j++)
                         {
                             zoneLines[i].Append(',');
-                            zoneLines[i].Append(CultureInfo.InvariantCulture, $"{ row[j]}");
+                            zoneLines[i].Append(CultureInfo.InvariantCulture, $"{row[j]}");
                         }
                     }
                 });

--- a/Code/TMG.Functions/Utilities.cs
+++ b/Code/TMG.Functions/Utilities.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+    Copyright 2025 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -16,7 +34,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static float ParseFloat(ReadOnlySpan<char> str)
     {
         if (!float.TryParse(str, out float value))
@@ -32,7 +50,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool TryParse(ReadOnlySpan<char> str, out float result)
     {
         if (float.TryParse(str, out result))
@@ -48,7 +66,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static double ParseDouble(ReadOnlySpan<char> str)
     {
         if (!double.TryParse(str, out double value))
@@ -64,7 +82,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool TryParse(ReadOnlySpan<char> str, out double result)
     {
         if (double.TryParse(str, out result))
@@ -80,7 +98,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static int ParseInt(ReadOnlySpan<char> str)
     {
         if (!int.TryParse(str, out int value))
@@ -96,7 +114,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool TryParse(ReadOnlySpan<char> str, out int result)
     {
         if (int.TryParse(str, out result))
@@ -112,7 +130,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool ParseBool(ReadOnlySpan<char> str)
     {
         // There is only the invariant culture for bool parsing in .NET at the moment.
@@ -126,7 +144,7 @@ public static class Utilities
     /// </summary>
     /// <param name="str">The string to parse</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool TryParse(ReadOnlySpan<char> str, out bool result)
     {
         // There is only the invariant culture for bool parsing in .NET at the moment.
@@ -139,8 +157,8 @@ public static class Utilities
     /// </summary>
     /// <param name="writer">The stream to write to.</param>
     /// <param name="data">The floating point data to write.</param>
-    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static void Write(StreamWriter writer, float data, Span<char> buffer)
     {
         if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
@@ -149,7 +167,7 @@ public static class Utilities
         }
         else
         {
-            writer.Write(data.ToString());
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
         }
     }
 
@@ -159,8 +177,236 @@ public static class Utilities
     /// </summary>
     /// <param name="writer">The stream to write to.</param>
     /// <param name="data">The floating point data to write.</param>
-    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    /// <param name="format">The format to use.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, float data, ReadOnlySpan<char> format, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, format, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a double to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 64 characters long to avoid needing to allocate.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, double data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a float to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="format">The format to use.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, double data, ReadOnlySpan<char> format, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, format, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes an integer to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, int data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a boolean to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, bool data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a DateTime to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, DateTime data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a TimeSpan to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void Write(StreamWriter writer, TimeSpan data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, "c"))
+        {
+            writer.Write(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.Write(data.ToString("c"));
+        }
+    }
+
+    /// <summary>
+    /// Writes an object to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long to avoid needing to allocate.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    public static void Write(StreamWriter writer, object data, Span<char> buffer)
+    {
+        switch(data)
+        {
+            case float f:
+                Write(writer, f, buffer);
+                return;
+            case double d:
+                Write(writer, d, buffer);
+                return;
+            case int i:
+                Write(writer, i, buffer);
+                return;
+            case bool b:
+                Write(writer, b, buffer);
+                return;
+            case char c:
+                writer.Write(c);
+                return;
+            case string s:
+                writer.Write(s);
+                return;
+            case DateTime dt:
+                Write(writer, dt, buffer);
+                return;
+            case TimeSpan ts:
+                Write(writer, ts, buffer);
+                return;
+            default:
+                writer.Write(data?.ToString() ?? string.Empty);
+                return;
+        }
+        
+    }
+
+    /// <summary>
+    /// Writes an object to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long to avoid needing to allocate.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveInlining)]
+    public static void WriteLine(StreamWriter writer, object data, Span<char> buffer)
+    {
+        switch (data)
+        {
+            case float f:
+                WriteLine(writer, f, buffer);
+                return;
+            case double d:
+                WriteLine(writer, d, buffer);
+                return;
+            case int i:
+                WriteLine(writer, i, buffer);
+                return;
+            case bool b:
+                WriteLine(writer, b, buffer);
+                return;
+            case char c:
+                writer.Write(c);
+                return;
+            case string s:
+                writer.Write(s);
+                return;
+            case DateTime dt:
+                WriteLine(writer, dt, buffer);
+                return;
+            case TimeSpan ts:
+                WriteLine(writer, ts, buffer);
+                return;
+            default:
+                writer.WriteLine(data?.ToString() ?? string.Empty);
+                return;
+        }
+
+    }
+
+    /// <summary>
+    /// Writes a float to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static void WriteLine(StreamWriter writer, float data, Span<char> buffer)
     {
         if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
@@ -169,8 +415,149 @@ public static class Utilities
         }
         else
         {
-            writer.WriteLine(data.ToString());
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
         }
     }
 
+    /// <summary>
+    /// Writes a double to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="format">The format to use.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, float data, ReadOnlySpan<char> format, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, format, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a double to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 64 characters long to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, double data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a double to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The floating point data to write.</param>
+    /// <param name="format">The format to use.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 64 characters long to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, double data, ReadOnlySpan<char> format, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, format, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes an integer to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, int data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a boolean to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 32 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, bool data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a DateTime to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, DateTime data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, provider: CultureInfo.InvariantCulture))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    /// <summary>
+    /// Writes a TimeSpan to a stream writer without doing an allocation using
+    /// the invariant culture where possible.
+    /// </summary>
+    /// <param name="writer">The stream to write to.</param>
+    /// <param name="data">The data to write.</param>
+    /// <param name="buffer">The temporary buffer to use. Should be 128 characters long in order to avoid allocation.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void WriteLine(StreamWriter writer, TimeSpan data, Span<char> buffer)
+    {
+        if (data.TryFormat(buffer, out int charactersWritten, "c"))
+        {
+            writer.WriteLine(buffer[0..charactersWritten]);
+        }
+        else
+        {
+            writer.WriteLine(data.ToString("c"));
+        }
+    }
 }

--- a/Code/TMGInterfaces/DataUtility/FloatList.cs
+++ b/Code/TMGInterfaces/DataUtility/FloatList.cs
@@ -18,6 +18,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace TMG.DataUtility;
@@ -207,7 +208,7 @@ public sealed class FloatList : IList<float>
         StringBuilder builder = new();
         for ( int i = 0; i < Values.Length; i++ )
         {
-            builder.Append( Values[i] );
+            builder.Append(CultureInfo.InvariantCulture, $"{Values[i]}");
             builder.Append( ',' );
         }
         return builder.ToString( 0, builder.Length - 1 );

--- a/Code/Tasha.Validation/Calibration/ExportAutoOwnershipResults.cs
+++ b/Code/Tasha.Validation/Calibration/ExportAutoOwnershipResults.cs
@@ -98,19 +98,20 @@ public sealed class ExportAutoOwnershipResults : IPostHousehold
         {
             return;
         }
+        Span<char> buffer = stackalloc char[32];
         using var writer = new StreamWriter(SaveTo);
         writer.WriteLine("ZoneNumber," + string.Join(',', Enumerable.Range(0, (MaxVehicles + 1) * 2).Select(i => $"Auto-{((i & 1) == 0 ? "Ground" : "Apartment")}-{i >> 1}")) + ",AdditionalCars");
         var flatZones = _zones.GetFlatData();
         for (var i = 0; i < flatZones.Length; i++)
         {
-            writer.Write(flatZones[i].ZoneNumber);
+            TMG.Functions.Utilities.Write(writer, flatZones[i].ZoneNumber, buffer);
             for (var j = 0; j < (MaxVehicles + 1) * 2; j++)
             {
                 writer.Write(',');
-                writer.Write(_autoCounts[(i * (MaxVehicles + 1) * 2) + j]);
+                TMG.Functions.Utilities.Write(writer, _autoCounts[(i * (MaxVehicles + 1) * 2) + j], buffer);
             }
             writer.Write(',');
-            writer.WriteLine(_householdsWithAdditionalCars[i]);
+            TMG.Functions.Utilities.WriteLine(writer, _householdsWithAdditionalCars[i], buffer);
         }
     }
 

--- a/Code/Tasha.Validation/Convergence/ODMatrixConvergence.cs
+++ b/Code/Tasha.Validation/Convergence/ODMatrixConvergence.cs
@@ -113,6 +113,7 @@ public sealed class ODMatrixConvergence : IPostIteration, ISelfContainedModule, 
 
     private void RecordData(int iterationNumber)
     {
+        Span<char> buffer = stackalloc char[32];
         var first = FirstMatrix.AcquireResource<SparseTwinIndex<float>>().GetFlatData();
         var second = SecondMatrix.AcquireResource<SparseTwinIndex<float>>().GetFlatData();
         float value = 0.0f;
@@ -125,9 +126,9 @@ public sealed class ODMatrixConvergence : IPostIteration, ISelfContainedModule, 
                 value = GetMax(first, second);
                 break;
         }
-        Writer.Write(iterationNumber + 1);
+        TMG.Functions.Utilities.Write(Writer, iterationNumber + 1, buffer);
         Writer.Write(',');
-        Writer.Write(value);
+        TMG.Functions.Utilities.Write(Writer, value, buffer);
         if (SumFirst)
         {
             var sum = 0.0f;
@@ -136,7 +137,7 @@ public sealed class ODMatrixConvergence : IPostIteration, ISelfContainedModule, 
                 sum += VectorHelper.Sum(first[i], 0, first[i].Length);
             }
             Writer.Write(',');
-            Writer.Write(sum);
+            TMG.Functions.Utilities.Write(Writer, sum, buffer);
         }
         Writer.WriteLine();
     }

--- a/Code/Tasha.Validation/Data/ExportSparseArrayOfFloat.cs
+++ b/Code/Tasha.Validation/Data/ExportSparseArrayOfFloat.cs
@@ -52,11 +52,12 @@ public class ExportSparseArrayOfFloat : IPostIteration, IPostRun
         var data = sparse.GetFlatData();
         using StreamWriter writer = new(OutputFile);
         writer.WriteLine("SparseIndex,Value");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < data.Length; i++)
         {
-            writer.Write(sparse.GetSparseIndex(i));
+            TMG.Functions.Utilities.Write(writer, sparse.GetSparseIndex(i), buffer);
             writer.Write(',');
-            writer.WriteLine(data[i]);
+            TMG.Functions.Utilities.WriteLine(writer, data[i], buffer);
         }
     }
 

--- a/Code/Tasha.Validation/DemographicSummery.cs
+++ b/Code/Tasha.Validation/DemographicSummery.cs
@@ -80,13 +80,14 @@ public class DemographicSummery : IPostHousehold
         }
         using StreamWriter writer = new(OutputFileName.GetFilePath());
         writer.WriteLine("AgeRange,ExpandedPersons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < AgeSets.Count; i++)
         {
-            writer.Write(AgeSets[i].Start);
+            TMG.Functions.Utilities.Write(writer, AgeSets[i].Start, buffer);
             writer.Write('-');
-            writer.Write(AgeSets[i].Stop);
+            TMG.Functions.Utilities.Write(writer, AgeSets[i].Stop, buffer);
             writer.Write(',');
-            writer.WriteLine(AgeSetCount[i]);
+            TMG.Functions.Utilities.WriteLine(writer, AgeSetCount[i], buffer);
         }
     }
 

--- a/Code/Tasha.Validation/ModeChoice/ConvertZonalModeSplitToPDModeSplit.cs
+++ b/Code/Tasha.Validation/ModeChoice/ConvertZonalModeSplitToPDModeSplit.cs
@@ -68,6 +68,7 @@ public class ConvertZonalModeSplitToPDModeSplit : IPostIteration
         var regionNumbers = regions.ValidIndexArray();
         using StreamWriter writer = new(PDModeSplitFile);
         writer.WriteLine("Mode,Origin,Destination,ExpandedTrips");
+        Span<char> buffer = stackalloc char[32];
         for (int m = 0; m < data.Length; m++)
         {
             string modeName = modes[m].ModeName + ",";
@@ -81,11 +82,11 @@ public class ConvertZonalModeSplitToPDModeSplit : IPostIteration
                     {
                         // this includes the comma already
                         writer.Write(modeName);
-                        writer.Write(regionNumbers[o]);
+                        TMG.Functions.Utilities.Write(writer, regionNumbers[o], buffer);
                         writer.Write(',');
-                        writer.Write(regionNumbers[d]);
+                        TMG.Functions.Utilities.Write(writer, regionNumbers[d], buffer);
                         writer.Write(',');
-                        writer.WriteLine(dRow[d]);
+                        TMG.Functions.Utilities.WriteLine(writer, dRow[d], buffer);
                     }
                 }
             }

--- a/Code/Tasha.Validation/ModeChoice/ConvertZonalModeSplitToRegionModeSplit.cs
+++ b/Code/Tasha.Validation/ModeChoice/ConvertZonalModeSplitToRegionModeSplit.cs
@@ -68,6 +68,7 @@ public class ConvertZonalModeSplitToRegionModeSplit : IPostIteration
         var regionNumbers = regions.ValidIndexArray();
         using StreamWriter writer = new(RegionModeSplitFile);
         writer.WriteLine("Mode,Origin,Destination,ExpandedTrips");
+        Span<char> buffer = stackalloc char[32];
         for (int m = 0; m < data.Length; m++)
         {
             string modeName = modes[m].ModeName + ",";
@@ -81,11 +82,11 @@ public class ConvertZonalModeSplitToRegionModeSplit : IPostIteration
                     {
                         // this includes the comma already
                         writer.Write(modeName);
-                        writer.Write(regionNumbers[o]);
+                        TMG.Functions.Utilities.Write(writer, regionNumbers[o], buffer);
                         writer.Write(',');
-                        writer.Write(regionNumbers[d]);
+                        TMG.Functions.Utilities.Write(writer, regionNumbers[d], buffer);
                         writer.Write(',');
-                        writer.WriteLine(dRow[d]);
+                        TMG.Functions.Utilities.WriteLine(writer, dRow[d], buffer);
                     }
                 }
             }

--- a/Code/Tasha.Validation/ModeChoice/ExtractPersonalAndTripRecords.cs
+++ b/Code/Tasha.Validation/ModeChoice/ExtractPersonalAndTripRecords.cs
@@ -1163,24 +1163,25 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessHouseholdRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(HouseholdRecords))
         {
             writer.WriteLine("household_id,home_zone,weight,persons,dwelling_type,vehicles,income_class");
             foreach (var household in _householdRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(household.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, household.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(household.HomeZone);
+                TMG.Functions.Utilities.Write(writer, household.HomeZone, buffer);
                 writer.Write(',');
-                writer.Write(household.ExpansionFactor);
+                TMG.Functions.Utilities.Write(writer, household.ExpansionFactor, buffer);
                 writer.Write(',');
-                writer.Write(household.NumberOfPersons);
+                TMG.Functions.Utilities.Write(writer, household.NumberOfPersons, buffer);
                 writer.Write(',');
-                writer.Write(household.DwellingType);
+                TMG.Functions.Utilities.Write(writer, household.DwellingType, buffer);
                 writer.Write(',');
-                writer.Write(household.NumberOfVehicles);
+                TMG.Functions.Utilities.Write(writer, household.NumberOfVehicles, buffer);
                 writer.Write(',');
-                writer.WriteLine(household.IncomeClass);
+                TMG.Functions.Utilities.WriteLine(writer, household.IncomeClass, buffer);
             }
         }
         if (CompressResults)
@@ -1191,6 +1192,7 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessPersonRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(PersonRecords))
         {
             writer.Write("household_id,person_id,age,sex,license,transit_pass,employment_status,occupation,free_parking" +
@@ -1206,11 +1208,11 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
             }
             foreach (var person in _personRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(person.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, person.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(person.PersonID);
+                TMG.Functions.Utilities.Write(writer, person.PersonID, buffer);
                 writer.Write(',');
-                writer.Write(person.Age);
+                TMG.Functions.Utilities.Write(writer, person.Age, buffer);
                 writer.Write(',');
                 writer.Write(person.Sex);
                 writer.Write(',');
@@ -1226,11 +1228,11 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
                 writer.Write(',');
                 writer.Write(person.StudentStatus);
                 writer.Write(',');
-                writer.Write(person.WorkZone);
+                TMG.Functions.Utilities.Write(writer, person.WorkZone, buffer);
                 writer.Write(',');
-                writer.Write(person.SchoolZone);
+                TMG.Functions.Utilities.Write(writer, person.SchoolZone, buffer);
                 writer.Write(',');
-                writer.Write(person.ExpFactor);
+                TMG.Functions.Utilities.Write(writer, person.ExpFactor, buffer);
                 if(writeTelecommuting)
                 {
                     writer.Write(',');
@@ -1247,30 +1249,31 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessTripRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(TripRecords))
         {
             writer.WriteLine("household_id,person_id,trip_id,o_act,o_zone,d_act,d_zone,weight,JointTourRep,JointTourRepTripId");
             foreach (var trip in _tripRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(trip.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, trip.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(trip.PersonID);
+                TMG.Functions.Utilities.Write(writer, trip.PersonID, buffer);
                 writer.Write(',');
-                writer.Write(trip.TripID);
+                TMG.Functions.Utilities.Write(writer, trip.TripID, buffer);
                 writer.Write(',');
                 writer.Write(trip.OriginActivity);
                 writer.Write(',');
-                writer.Write(trip.OriginZone);
+                TMG.Functions.Utilities.Write(writer, trip.OriginZone, buffer);
                 writer.Write(',');
                 writer.Write(trip.DestinationActivity);
                 writer.Write(',');
-                writer.Write(trip.DestinationZone);
+                TMG.Functions.Utilities.Write(writer, trip.DestinationZone, buffer);
                 writer.Write(',');
-                writer.Write(trip.ExpFactor);
+                TMG.Functions.Utilities.Write(writer, trip.ExpFactor, buffer);
                 writer.Write(',');
-                writer.Write(trip.JointTourRep);
+                TMG.Functions.Utilities.Write(writer, trip.JointTourRep, buffer);
                 writer.Write(',');
-                writer.WriteLine(trip.JointTourRepTripId);
+                TMG.Functions.Utilities.WriteLine(writer, trip.JointTourRepTripId, buffer);
             }
         }
         if (CompressResults)
@@ -1281,24 +1284,25 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessModeRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(TripModeRecords))
         {
             writer.WriteLine("household_id,person_id,trip_id,mode,o_depart,d_arrive,weight");
             foreach (var mode in _modeRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(mode.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, mode.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(mode.PersonID);
+                TMG.Functions.Utilities.Write(writer, mode.PersonID, buffer);
                 writer.Write(',');
-                writer.Write(mode.TripID);
+                TMG.Functions.Utilities.Write(writer, mode.TripID, buffer);
                 writer.Write(',');
                 writer.Write(mode.Mode);
                 writer.Write(',');
                 if (ExportTimesAsMinutes)
                 {
-                    writer.Write(mode.OriginDeparture.ToMinutes());
+                    TMG.Functions.Utilities.Write(writer, mode.OriginDeparture.ToMinutes(), buffer);
                     writer.Write(',');
-                    writer.Write(mode.DestinationArrivalTime.ToMinutes());
+                    TMG.Functions.Utilities.Write(writer, mode.DestinationArrivalTime.ToMinutes(), buffer);
                 }
                 else
                 {
@@ -1308,7 +1312,7 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
                 }
                 writer.Write(',');
-                writer.WriteLine(mode.Weight);
+                TMG.Functions.Utilities.WriteLine(writer, mode.Weight, buffer);
             }
         }
         if (CompressResults)
@@ -1319,22 +1323,23 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessStationRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(TripStationRecords))
         {
             writer.WriteLine("household_id,person_id,trip_id,station,direction,weight,mode");
             foreach (var station in _stationRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(station.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, station.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(station.PersonID);
+                TMG.Functions.Utilities.Write(writer, station.PersonID, buffer);
                 writer.Write(',');
-                writer.Write(station.TripID);
+                TMG.Functions.Utilities.Write(writer, station.TripID, buffer);
                 writer.Write(',');
-                writer.Write(station.StationID);
+                TMG.Functions.Utilities.Write(writer, station.StationID, buffer);
                 writer.Write(',');
                 writer.Write(station.ToTransit ? "auto2transit" : "transit2auto");
                 writer.Write(',');
-                writer.Write(station.Weight);
+                TMG.Functions.Utilities.Write(writer, station.Weight, buffer);
                 writer.Write(',');
                 writer.WriteLine(station.Mode);
             }
@@ -1347,22 +1352,23 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
 
     private void ProcessFacilitatePassengerRecords()
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(FacilitatePassengerRecords))
         {
             writer.WriteLine("household_id,passenger_id,passenger_trip_id,driver_id,driver_trip_id,weight");
             foreach (var passengerTrip in _facilitatePassengerRecordQueue.GetConsumingEnumerable())
             {
-                writer.Write(passengerTrip.HouseholdID);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.HouseholdID, buffer);
                 writer.Write(',');
-                writer.Write(passengerTrip.PassengerID);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.PassengerID, buffer);
                 writer.Write(',');
-                writer.Write(passengerTrip.PassengerTripID);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.PassengerTripID, buffer);
                 writer.Write(',');
-                writer.Write(passengerTrip.DriverID);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.DriverID, buffer);
                 writer.Write(',');
-                writer.Write(passengerTrip.DriverTripID);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.DriverTripID, buffer);
                 writer.Write(',');
-                writer.WriteLine(passengerTrip.Weight);
+                TMG.Functions.Utilities.Write(writer, passengerTrip.Weight, buffer);
             }
         }
         if (CompressResults)

--- a/Code/Tasha.Validation/ModeChoice/ModeSplit.cs
+++ b/Code/Tasha.Validation/ModeChoice/ModeSplit.cs
@@ -87,14 +87,15 @@ public class ModeSplit : IPostHousehold
     {
         using (var writer = new StreamWriter(OutputFileLocation, true))
         {
+            Span<char> buffer = stackalloc char[32];
             writer.Write("Iteration: ");
-            writer.WriteLine(iteration);
+            TMG.Functions.Utilities.Write(writer, iteration, buffer);
             writer.WriteLine("Mode,ExpandedTrips");
             for (int i = 0; i < Modes.Length; i++)
             {
                 writer.Write(Modes[i].ModeName);
                 writer.Write(',');
-                writer.WriteLine(Counts[i]);
+                TMG.Functions.Utilities.WriteLine(writer, Counts[i], buffer);
             }
         }
         for (int i = 0; i < Counts.Length; i++)

--- a/Code/Tasha.Validation/ModeChoice/ModeSplitsByPersonAttributes.cs
+++ b/Code/Tasha.Validation/ModeChoice/ModeSplitsByPersonAttributes.cs
@@ -209,6 +209,7 @@ public sealed class ModeSplitsByPersonAttributes : IPostHouseholdIteration
             var occString = Root.Occupations.Select(o => Enum.GetName(typeof(Occupation), o)).ToArray();
             var empString = Root.EmploymentStatuses.Select(e => Enum.GetName(typeof(TTSEmploymentStatus), e)).ToArray();
             var modeString = allModes.Select(m => m.ModeName).ToArray();
+            Span<char> buffer = stackalloc char[32];
             for (int ageCat = 0; ageCat < Root.AgeRanges.Count; ageCat++)
             {
                 for (int occCat = 0; occCat < Root.Occupations.Length; occCat++)
@@ -226,7 +227,7 @@ public sealed class ModeSplitsByPersonAttributes : IPostHouseholdIteration
                             writer.Write(',');
                             writer.Write(modeString[mode]);
                             writer.Write(',');
-                            writer.WriteLine(DataStorage[offset + mode]);
+                            TMG.Functions.Utilities.WriteLine(writer, DataStorage[offset + mode], buffer);
                         }
                     }
                 }

--- a/Code/Tasha.Validation/ModeChoice/StartTimeDistributions.cs
+++ b/Code/Tasha.Validation/ModeChoice/StartTimeDistributions.cs
@@ -176,6 +176,7 @@ public class StartTimeDistributions : IPostHousehold, IPostHouseholdIteration
         writer.WriteLine();
         Time thirtyMinutes = new() { Minutes = 30 };
         Time currentTime = new();
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < NumberOfTimeBins; i++)
         {
             writer.Write(currentTime);
@@ -185,7 +186,7 @@ public class StartTimeDistributions : IPostHousehold, IPostHouseholdIteration
                 for (int j = 0; j < purposeData.Length; j++)
                 {
                     writer.Write(',');
-                    writer.Write(purposeData[j]);
+                    TMG.Functions.Utilities.Write(writer, purposeData[j], buffer);
                 }
             }
             writer.WriteLine();

--- a/Code/Tasha.Validation/ModeChoice/TimePeriodModeSplit.cs
+++ b/Code/Tasha.Validation/ModeChoice/TimePeriodModeSplit.cs
@@ -176,7 +176,8 @@ public class TimePeriodModeSplit : IPostHousehold
             counts[i] = TimePeriods.Sum(period => period.Counts.Sum((type) => type.Value[i]));
         }
         IterationTotals.Add(counts);
-        using(var writer = new StreamWriter(OutputFileLocation, true))
+        Span<char> buffer = stackalloc char[32];
+        using (var writer = new StreamWriter(OutputFileLocation, true))
         {
             writer.Write("Iteration: ");
             writer.WriteLine(iteration);
@@ -200,11 +201,11 @@ public class TimePeriodModeSplit : IPostHousehold
                     foreach(var key in TimePeriods[j].Counts.Keys)
                     {
                         writer.Write(',');
-                        writer.Write(TimePeriods[j].Counts[key][i]);
+                        TMG.Functions.Utilities.Write(writer, TimePeriods[j].Counts[key][i], buffer);
                     }
                 }
                 writer.Write(',');
-                writer.WriteLine(counts[i]);
+                TMG.Functions.Utilities.WriteLine(writer, counts[i], buffer);
             }
             if(iteration >= Root.TotalIterations - 1)
             {
@@ -220,15 +221,15 @@ public class TimePeriodModeSplit : IPostHousehold
                 for(int it = 0; it < IterationTotals.Count; it++)
                 {
                     var row = IterationTotals[it];
-                    writer.Write((it + 1));
+                    TMG.Functions.Utilities.Write(writer, (it + 1), buffer);
                     for(int i = 0; i < row.Length; i++)
                     {
                         writer.Write(',');
-                        writer.Write(row[i]);
+                        TMG.Functions.Utilities.Write(writer, row[i], buffer);
                     }
                     writer.Write(',');
                     writer.Write(',');
-                    writer.WriteLine(row.Sum());
+                    TMG.Functions.Utilities.WriteLine(writer, row.Sum(), buffer);
                 }
             }
         }

--- a/Code/Tasha.Validation/ModeChoice/ZonalModeSplits.cs
+++ b/Code/Tasha.Validation/ModeChoice/ZonalModeSplits.cs
@@ -119,7 +119,8 @@ public class ZonalModeSplits : IPostHouseholdIteration
         using (StreamWriter writer = new(SaveLocation))
         {
             writer.WriteLine("Mode,Origin,Destination,ExpandedTrips");
-            for(int m = 0; m < Data.Length; m++)
+            Span<char> buffer = stackalloc char[256];
+            for (int m = 0; m < Data.Length; m++)
             {
                 string modeName = Modes[m].ModeName + ",";
                 var oRow = Data[m];
@@ -132,11 +133,11 @@ public class ZonalModeSplits : IPostHouseholdIteration
                         {
                             // this includes the comma already
                             writer.Write(modeName);
-                            writer.Write(zones[o]);
+                            TMG.Functions.Utilities.Write(writer, zones[o], buffer);
                             writer.Write(',');
-                            writer.Write(zones[d]);
+                            TMG.Functions.Utilities.Write(writer, zones[d], buffer);
                             writer.Write(',');
-                            writer.WriteLine(dRow[d]);
+                            TMG.Functions.Utilities.WriteLine(writer, dRow[d], buffer);
                         }
                     }
                 }

--- a/Code/Tasha.Validation/NWS/NWSTLFD.cs
+++ b/Code/Tasha.Validation/NWS/NWSTLFD.cs
@@ -171,6 +171,7 @@ public class NWSTLFD : IPostHousehold
 
     public void IterationFinished(int iteration)
     {
+        Span<char> buffer = stackalloc char[32];
         using var writer = new StreamWriter(SaveTo);
         var bins = _abb.NumberOfBins;
         WriteHeader(writer);
@@ -178,39 +179,39 @@ public class NWSTLFD : IPostHousehold
         // intrazonal
         writer.Write("intrazonal,0");
         writer.Write(',');
-        writer.Write(_abb.Intrazonal);
+        TMG.Functions.Utilities.Write(writer, _abb.Intrazonal, buffer);
         writer.Write(',');
-        writer.Write(_hbm.Intrazonal);
+        TMG.Functions.Utilities.Write(writer, _hbm.Intrazonal, buffer);
         writer.Write(',');
-        writer.Write(_hbo.Intrazonal);
+        TMG.Functions.Utilities.Write(writer, _hbo.Intrazonal, buffer);
         writer.Write(',');
-        writer.WriteLine(_nhb.Intrazonal);
+        TMG.Functions.Utilities.WriteLine(writer, _nhb.Intrazonal, buffer);
         // bins
         for (int i = 0; i < bins; i++)
         {
-            writer.Write(from);
+            TMG.Functions.Utilities.Write(writer, from, buffer);
             writer.Write(',');
-            writer.Write(from + StepSize);
+            TMG.Functions.Utilities.Write(writer, from + StepSize, buffer);
             writer.Write(',');
-            writer.Write(_abb.Bins[i]);
+            TMG.Functions.Utilities.Write(writer, _abb.Bins[i], buffer);
             writer.Write(',');
-            writer.Write(_hbm.Bins[i]);
+            TMG.Functions.Utilities.Write(writer, _hbm.Bins[i], buffer);
             writer.Write(',');
-            writer.Write(_hbo.Bins[i]);
+            TMG.Functions.Utilities.Write(writer, _hbo.Bins[i], buffer);
             writer.Write(',');
-            writer.WriteLine(_nhb.Bins[i]);
+            TMG.Functions.Utilities.WriteLine(writer, _nhb.Bins[i], buffer);
             from += StepSize;
         }
         // over last bin
-        writer.Write(from);
+        TMG.Functions.Utilities.Write(writer, from, buffer);
         writer.Write(",inf,");
-        writer.Write(_abb.BeyondMax);
+        TMG.Functions.Utilities.Write(writer, _abb.BeyondMax, buffer);
         writer.Write(',');
-        writer.Write(_hbm.BeyondMax);
+        TMG.Functions.Utilities.Write(writer, _hbm.BeyondMax, buffer);
         writer.Write(',');
-        writer.Write(_hbo.BeyondMax);
+        TMG.Functions.Utilities.Write(writer, _hbo.BeyondMax, buffer);
         writer.Write(',');
-        writer.WriteLine(_nhb.BeyondMax);
+        TMG.Functions.Utilities.WriteLine(writer, _nhb.BeyondMax, buffer);
     }
 
     private void WriteHeader(StreamWriter writer)

--- a/Code/Tasha.Validation/ProjectScheduleAnalysis.cs
+++ b/Code/Tasha.Validation/ProjectScheduleAnalysis.cs
@@ -132,11 +132,12 @@ public class ProjectScheduleAnalysis : IPostScheduler
     {
         using StreamWriter writer = new(file);
         writer.WriteLine("Bin,Data");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < data.Length; i++)
         {
-            writer.Write(i);
+            TMG.Functions.Utilities.Write(writer, i, buffer);
             writer.Write(',');
-            writer.WriteLine(data[i]);
+            TMG.Functions.Utilities.WriteLine(writer, data[i], buffer);
         }
     }
 

--- a/Code/Tasha.Validation/Scheduler/SaveTripLengthFrequencyDistribution.cs
+++ b/Code/Tasha.Validation/Scheduler/SaveTripLengthFrequencyDistribution.cs
@@ -96,18 +96,18 @@ public sealed class SaveTripLengthFrequencyDistribution : ISelfContainedModule
             using var writer = new StreamWriter(SaveTo);
             writer.WriteLine("Min,Max,Value");
             writer.Write("intrazonal,0,");
-            writer.WriteLine(intrazonal);
+            TMG.Functions.Utilities.WriteLine(writer, intrazonal, buffer);
             for (int i = 0; i < bins.Length; i++)
             {
-                writer.Write(i * Stride);
+                TMG.Functions.Utilities.Write(writer, i * Stride, buffer);
                 writer.Write(',');
-                writer.Write((i + 1) * Stride);
+                TMG.Functions.Utilities.Write(writer, (i + 1) * Stride, buffer);
                 writer.Write(',');
                 TMG.Functions.Utilities.WriteLine(writer, bins[i], buffer);
             }
-            writer.Write(Stride * bins.Length);
+            TMG.Functions.Utilities.Write(writer, Stride * bins.Length, buffer);
             writer.Write(",inf,");
-            writer.WriteLine(pastBins);
+            TMG.Functions.Utilities.WriteLine(writer, pastBins, buffer);
         }
         catch(IOException e)
         {

--- a/Code/Tasha.Validation/Scheduler/TripChainSizeVSDailyTrips.cs
+++ b/Code/Tasha.Validation/Scheduler/TripChainSizeVSDailyTrips.cs
@@ -66,23 +66,24 @@ public class TripChainSizeVSDailyTrips : IPostHousehold
 
     public void IterationFinished(int iteration)
     {
+        Span<char> buffer = stackalloc char[32];
         using StreamWriter writer = new(OutputLocation);
         //write header
         writer.Write("TripChainSize\\DailyTripCount");
         for (int i = 0; i < Results.Length; i++)
         {
             writer.Write(',');
-            writer.Write(i);
+            TMG.Functions.Utilities.Write(writer, i, buffer);
         }
         writer.WriteLine();
         // for each row
         for (int i = 0; i < Results.Length; i++)
         {
-            writer.Write(i);
+            TMG.Functions.Utilities.Write(writer, i, buffer);
             for (int j = 0; j < Results[i].Length; j++)
             {
                 writer.Write(',');
-                writer.Write(Results[i][j]);
+                TMG.Functions.Utilities.Write(writer, Results[i][j], buffer);
             }
             writer.WriteLine();
         }

--- a/Code/Tasha.Validation/TripExtraction/ExtractAccessStationOD.cs
+++ b/Code/Tasha.Validation/TripExtraction/ExtractAccessStationOD.cs
@@ -26,6 +26,7 @@ using TMG;
 using Datastructure;
 using System.Runtime.CompilerServices;
 using System.IO;
+using System.Globalization;
 
 namespace Tasha.Validation.TripExtraction;
 
@@ -148,10 +149,11 @@ public class ExtractAccessStationOD : IPostHouseholdIteration
     public void IterationFinished(int iteration, int totalIterations)
     {
         var results = Results;
-        var zoneNumbers = Zones.GetFlatData().Select(z => z.ZoneNumber.ToString()).ToArray();
-        var stationIndexStr = StationIndex.Select(z => z.ToString()).ToArray();
+        var zoneNumbers = Zones.GetFlatData().Select(z => z.ZoneNumber.ToString(CultureInfo.InvariantCulture)).ToArray();
+        var stationIndexStr = StationIndex.Select(z => z.ToString(CultureInfo.InvariantCulture)).ToArray();
         using var writer = new StreamWriter(SaveTo);
         writer.WriteLine("Station,Origin,Destination,Trips");
+        Span<char> buffer = stackalloc char[32];
         for (int sIndex = 0; sIndex < results.Length; sIndex++)
         {
             for (int o = 0; o < results[sIndex].Length; o++)
@@ -166,7 +168,7 @@ public class ExtractAccessStationOD : IPostHouseholdIteration
                         writer.Write(',');
                         writer.Write(zoneNumbers[d]);
                         writer.Write(',');
-                        writer.WriteLine(results[sIndex][o][d]);
+                        TMG.Functions.Utilities.WriteLine(writer, results[sIndex][o][d], buffer);
                     }
                 }
             }

--- a/Code/Tasha.Validation/TripExtraction/ExtractSelectedDemographicTripRecords.cs
+++ b/Code/Tasha.Validation/TripExtraction/ExtractSelectedDemographicTripRecords.cs
@@ -106,15 +106,16 @@ public class ExtractSelectedDemographicTripRecords : IPostHouseholdIteration, ID
     private void SaveTrip(ITrip trip, int householdNumber, int personNumber, int tripNumber, int numberOfWorkTrips, int numberOfTripsInTour)
     {
         var writer = Writer;
-        writer.Write(householdNumber);
+        Span<char> buffer = stackalloc char[32];
+        TMG.Functions.Utilities.Write(writer, householdNumber, buffer);
         writer.Write(',');
-        writer.Write(personNumber);
+        TMG.Functions.Utilities.Write(writer, personNumber, buffer);
         writer.Write(',');
-        writer.Write(tripNumber);
+        TMG.Functions.Utilities.Write(writer, tripNumber, buffer);
         writer.Write(',');
-        writer.Write(trip.OriginalZone.ZoneNumber);
+        TMG.Functions.Utilities.Write(writer, trip.OriginalZone.ZoneNumber, buffer);
         writer.Write(',');
-        writer.Write(trip.DestinationZone.ZoneNumber);
+        TMG.Functions.Utilities.Write(writer, trip.DestinationZone.ZoneNumber, buffer);
         writer.Write(',');
         writer.Write(GetPurposeName(trip.Purpose));
         writer.Write(',');
@@ -122,16 +123,16 @@ public class ExtractSelectedDemographicTripRecords : IPostHouseholdIteration, ID
         writer.Write(',');
         writer.Write(trip.ActivityStartTime);
         writer.Write(',');
-        writer.Write(GetTripDistance(trip));
+        TMG.Functions.Utilities.Write(writer, GetTripDistance(trip), buffer);
         writer.Write(',');
-        writer.Write(numberOfWorkTrips);
+        TMG.Functions.Utilities.Write(writer, numberOfWorkTrips, buffer);
         writer.Write(',');
-        writer.Write(numberOfTripsInTour);
+        TMG.Functions.Utilities.Write(writer, numberOfTripsInTour, buffer);
         var modesChosen = trip.ModesChosen;
         for (int i = 0; i < AllModes.Length; i++)
         {
             writer.Write(',');
-            writer.Write(modesChosen.Count(m => m == AllModes[i]));
+            TMG.Functions.Utilities.Write(writer, modesChosen.Count(m => m == AllModes[i]), buffer);
         }
         writer.WriteLine();
     }

--- a/Code/Tasha.Validation/ValidateModeChoice/HouseholdUtilities.cs
+++ b/Code/Tasha.Validation/ValidateModeChoice/HouseholdUtilities.cs
@@ -58,6 +58,7 @@ public class HouseholdUtilities : IPostHouseholdIteration
             {
                 var writeHeader = !File.Exists(OutputFile);
                 using StreamWriter writer = new(OutputFile, true);
+                Span<char> buffer = stackalloc char[32];
                 if (writeHeader)
                 {
                     writer.WriteLine("HouseholdID,HouseholdIteration,Household Utility");
@@ -65,11 +66,11 @@ public class HouseholdUtilities : IPostHouseholdIteration
                 var util = Utilities[household.HouseholdId];
                 for (int i = 0; i < util.Length; i++)
                 {
-                    writer.Write(household.HouseholdId);
+                    TMG.Functions.Utilities.Write(writer, household.HouseholdId, buffer);
                     writer.Write(',');
-                    writer.Write(i);
+                    TMG.Functions.Utilities.Write(writer, i, buffer);
                     writer.Write(',');
-                    writer.WriteLine(util[i]);
+                    TMG.Functions.Utilities.WriteLine(writer, util[i], buffer);
                 }
             }
         }

--- a/Code/XTMF/ModelSystemStructure.cs
+++ b/Code/XTMF/ModelSystemStructure.cs
@@ -1751,6 +1751,14 @@ public class ModelSystemStructure : IModelSystemStructure2
                 {
                     writer.WriteAttributeString("Value", ul.ToString(CultureInfo.InvariantCulture));
                 }
+                else if (param.Value is DateTime dt)
+                {
+                    writer.WriteAttributeString("Value", dt.ToString("o", CultureInfo.InvariantCulture));
+                }
+                else if (param.Value is TimeSpan ts)
+                {
+                    writer.WriteAttributeString("Value", ts.ToString("c", CultureInfo.InvariantCulture));
+                }
                 else
                 {
                     writer.WriteAttributeString("Value", param.Value == null ? String.Empty : param.Value.ToString());

--- a/Code/XTMF/ModelSystemStructure.cs
+++ b/Code/XTMF/ModelSystemStructure.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -1676,7 +1677,7 @@ public class ModelSystemStructure : IModelSystemStructure2
         }
         else
         {
-            writer.WriteAttributeString("TIndex", lookup[s.Type].ToString());
+            writer.WriteAttributeString("TIndex", lookup[s.Type].ToString(CultureInfo.InvariantCulture));
         }
         if (s.ParentFieldType == null)
         {
@@ -1684,7 +1685,7 @@ public class ModelSystemStructure : IModelSystemStructure2
         }
         else
         {
-            writer.WriteAttributeString("ParentTIndex", lookup[s.ParentFieldType].ToString());
+            writer.WriteAttributeString("ParentTIndex", lookup[s.ParentFieldType].ToString(CultureInfo.InvariantCulture));
         }
         writer.WriteAttributeString("ParentFieldName", s.ParentFieldName);
         if (s.IsMetaModule)
@@ -1721,8 +1722,39 @@ public class ModelSystemStructure : IModelSystemStructure2
                 {
                     writer.WriteAttributeString("FriendlyName", p.Name);
                 }
-                writer.WriteAttributeString("TIndex", lookup[param.Type ?? param.Value.GetType()].ToString());
-                writer.WriteAttributeString("Value", param.Value == null ? String.Empty : param.Value.ToString());
+                writer.WriteAttributeString("TIndex", lookup[param.Type ?? param.Value.GetType()].ToString(CultureInfo.InvariantCulture));
+                if (param.Value is float f)
+                {
+                    writer.WriteAttributeString("Value", f.ToString(CultureInfo.InvariantCulture));
+                }
+                else if(param.Value is double d)
+                {
+                    writer.WriteAttributeString("Value", d.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (param.Value is int i)
+                {
+                    writer.WriteAttributeString("Value", i.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (param.Value is long l)
+                {
+                    writer.WriteAttributeString("Value", l.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (param.Value is bool b)
+                {
+                    writer.WriteAttributeString("Value", b ? "true" : "false");
+                }
+                else if(param.Value is uint u)
+                {
+                    writer.WriteAttributeString("Value", u.ToString(CultureInfo.InvariantCulture));
+                }
+                else if (param.Value is ulong ul)
+                {
+                    writer.WriteAttributeString("Value", ul.ToString(CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    writer.WriteAttributeString("Value", param.Value == null ? String.Empty : param.Value.ToString());
+                }
                 if (param.QuickParameter)
                 {
                     writer.WriteAttributeString("QuickParameter", "true");

--- a/Code/XTMF/Project_IO.cs
+++ b/Code/XTMF/Project_IO.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -543,7 +544,7 @@ public sealed partial class Project : IProject
             writer.WriteAttributeString("Name", lp.Name);
             if (lp.Value != null)
             {
-                writer.WriteAttributeString("Value", lp.Value.ToString());
+                writer.WriteAttributeString("Value", lp.Value.ToString(CultureInfo.InvariantCulture));
             }
             foreach (var reference in lp.Parameters)
             {

--- a/Code/XTMFTesting/TMG/Data/Loading/TestLoadODDataFromCSV.cs
+++ b/Code/XTMFTesting/TMG/Data/Loading/TestLoadODDataFromCSV.cs
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
+using System.Globalization;
 using TMG.Frameworks.Data.Loading;
 using TMG.Input;
 
@@ -38,6 +39,7 @@ public class TestLoadODDataFromCSV
                     data[i, j] = i;
                 }
             }
+            Span<char> buffer = stackalloc char[32];
             using (var writer = new StreamWriter(tempFile))
             {
                 writer.Write("origin\\destination");
@@ -53,7 +55,7 @@ public class TestLoadODDataFromCSV
                     for (int j = 0; j < data.GetLength(1); j++)
                     {
                         writer.Write(',');
-                        writer.Write(data[i, j]);
+                        global::TMG.Functions.Utilities.Write(writer, data[i, j], buffer);
                     }
                     writer.WriteLine();
                 }
@@ -112,7 +114,7 @@ public class TestLoadODDataFromCSV
                         writer.Write(',');
                         writer.Write(j);
                         writer.Write(',');
-                        writer.WriteLine(data[i, j]);
+                        writer.WriteLine(data[i, j].ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -171,7 +173,7 @@ public class TestLoadODDataFromCSV
                         writer.Write(',');
                         writer.Write(j);
                         writer.Write(',');
-                        writer.WriteLine(data[i, j]);
+                        writer.WriteLine(data[i, j].ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -228,7 +230,7 @@ public class TestLoadODDataFromCSV
                     {
                         writer.Write(i);
                         writer.Write(',');
-                        writer.WriteLine(data[i, 0]);
+                        writer.WriteLine(data[i, 0].ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }
@@ -289,7 +291,7 @@ public class TestLoadODDataFromCSV
                     {
                         writer.Write(i);
                         writer.Write(',');
-                        writer.WriteLine(data[i, 0]);
+                        writer.WriteLine(data[i, 0].ToString(CultureInfo.InvariantCulture));
                     }
                 }
             }

--- a/Code/XTMFTesting/TMG/Data/TestLabeledData.cs
+++ b/Code/XTMFTesting/TMG/Data/TestLabeledData.cs
@@ -117,7 +117,7 @@ public class TestLabeledData
                     writer.Write(',');
                     writer.Write((char)('a' + i));
                     writer.Write(',');
-                    writer.WriteLine(1.0f);
+                    writer.WriteLine("1.0");
                 }
             }
             // now that our data files have been created create the aggregation

--- a/Tasha/DataExtraction/ExtractBaseYearStudentLinkages.cs
+++ b/Tasha/DataExtraction/ExtractBaseYearStudentLinkages.cs
@@ -143,6 +143,7 @@ GROUP BY [{0}].[{1}], [{3}].[SchoolZone];",
             }
         }
         var flatResult = result.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(OutputFileName.GetFilePath()))
         {
             writer.WriteLine("HomeZone,SchoolZone,People");
@@ -154,11 +155,11 @@ GROUP BY [{0}].[{1}], [{3}].[SchoolZone];",
                 {
                     if (row[j] > 0)
                     {
-                        writer.Write(iAsString);
+                        TMG.Functions.Utilities.Write(writer, iAsString, buffer);
                         writer.Write(',');
-                        writer.Write(flatZones[j].ZoneNumber);
+                        TMG.Functions.Utilities.Write(writer, flatZones[j].ZoneNumber, buffer);
                         writer.Write(',');
-                        writer.WriteLine(row[j]);
+                        TMG.Functions.Utilities.WriteLine(writer, row[j], buffer);
                     }
                 }
             }
@@ -228,7 +229,7 @@ GROUP BY [{3}].[{0}];",
                 }
                 else
                 {
-                    writer.WriteLine(flatPdStudents[i] / pop);
+                    TMG.Functions.Utilities.WriteLine(writer, flatPdStudents[i] / pop, buffer);
                 }
             }
         }

--- a/Tasha/DataExtraction/ExtractObservedDemandToPD.cs
+++ b/Tasha/DataExtraction/ExtractObservedDemandToPD.cs
@@ -159,6 +159,7 @@ public class ExtractObservedDemandToPD : IPostHousehold
             writer.WriteLine();
             //The main body of the loop is going to end the line
             //write body
+            Span<char> buffer = stackalloc char[32];
             for (int mode = 0; mode < Demand.Length; mode++)
             {
                 writer.WriteLine(Parent.Modes[mode].ModeName);
@@ -183,7 +184,7 @@ public class ExtractObservedDemandToPD : IPostHousehold
                             }
                         }
                         writer.Write(',');
-                        writer.Write(row[j]);
+                        TMG.Functions.Utilities.Write(writer, row[j], buffer);
                     }
                     writer.WriteLine();
                 }

--- a/Tasha/DataExtraction/GatherAgeByPD.cs
+++ b/Tasha/DataExtraction/GatherAgeByPD.cs
@@ -93,6 +93,7 @@ public class GatherAgeByPD : ISelfContainedModule
 
     private void SaveData(SparseArray<float>[] pdData)
     {
+        Span<char> buffer = stackalloc char[32];
         var pdIndexes = pdData[0].ValidIndexArray();
         using var writer = new StreamWriter(OutputFileName.GetFilePath());
         writer.WriteLine("PD,AgeCategory,ExpandedPopulation");
@@ -101,11 +102,11 @@ public class GatherAgeByPD : ISelfContainedModule
             var pdArray = pdData[i];
             for (int j = 0; j < pdIndexes.Length; j++)
             {
-                writer.Write(pdIndexes[j]);
+                TMG.Functions.Utilities.Write(writer, pdIndexes[j], buffer);
                 writer.Write(',');
-                writer.Write(i);
+                TMG.Functions.Utilities.Write(writer, i, buffer);
                 writer.Write(',');
-                writer.WriteLine(pdArray[pdIndexes[j]]);
+                TMG.Functions.Utilities.WriteLine(writer, pdArray[pdIndexes[j]], buffer);
             }
         }
     }

--- a/Tasha/DataExtraction/GatherEmploymentByAgeByPD.cs
+++ b/Tasha/DataExtraction/GatherEmploymentByAgeByPD.cs
@@ -102,6 +102,7 @@ public class GatherEmploymentByAgeByPD : ISelfContainedModule
 
     private void SaveData(SparseArray<float>[] pdData, int ageCat)
     {
+        Span<char> buffer = stackalloc char[32];
         var pdIndexes = pdData[0].ValidIndexArray();
         using var writer = new StreamWriter(OutputFileName.GetFilePath(), ageCat != 0);
         if (ageCat == 0)
@@ -113,13 +114,13 @@ public class GatherEmploymentByAgeByPD : ISelfContainedModule
             var pdArray = pdData[empStat];
             for (int j = 0; j < pdIndexes.Length; j++)
             {
-                writer.Write(pdIndexes[j]);
+                TMG.Functions.Utilities.Write(writer, pdIndexes[j], buffer);
                 writer.Write(',');
-                writer.Write(empStat);
+                TMG.Functions.Utilities.Write(writer, empStat, buffer);
                 writer.Write(',');
-                writer.Write(ageCat);
+                TMG.Functions.Utilities.Write(writer, ageCat, buffer);
                 writer.Write(',');
-                writer.WriteLine(pdArray[pdIndexes[j]]);
+                TMG.Functions.Utilities.WriteLine(writer, pdArray[pdIndexes[j]], buffer);
             }
         }
     }

--- a/Tasha/DataExtraction/GatherOccupationByEmpStatByPD.cs
+++ b/Tasha/DataExtraction/GatherOccupationByEmpStatByPD.cs
@@ -118,6 +118,7 @@ public class GatherOccupationByEmpStatByPD : ISelfContainedModule
     /// <param name="empCode">The empStat code to dump</param>
     private void WriteData(StreamWriter writer, SparseArray<float[]> splitData, char empCode)
     {
+        Span<char> buffer = stackalloc char[32];
         var data = splitData.GetFlatData();
         for ( int i = 0; i < data.Length; i++ )
         {
@@ -128,10 +129,10 @@ public class GatherOccupationByEmpStatByPD : ISelfContainedModule
                 var pdStr = string.Concat( empCode, ",", splitData.GetFlatIndex( i ), "," );
                 for ( int j = 0; j < row.Length; j++ )
                 {
-                    writer.Write( pdStr );
-                    writer.Write( j + 1 );
+                    writer.Write(pdStr);
+                    TMG.Functions.Utilities.Write(writer, j + 1, buffer);
                     writer.Write( ',' );
-                    writer.WriteLine( row[j] );
+                    TMG.Functions.Utilities.WriteLine(writer, row[j], buffer);
                 }
             }
         }

--- a/Tasha/DataExtraction/GatherPopulationByZone.cs
+++ b/Tasha/DataExtraction/GatherPopulationByZone.cs
@@ -82,6 +82,7 @@ public class GatherPopulationByZone : ISelfContainedModule
 
     private void WritePopulation(float[] population, SparseArray<IZone> zones)
     {
+        Span<char> buffer = stackalloc char[32];
         var flatZones = zones.GetFlatData();
         using var writer = new StreamWriter(OutputFile.GetFilePath());
         writer.WriteLine("Zone,Population");
@@ -89,7 +90,7 @@ public class GatherPopulationByZone : ISelfContainedModule
         {
             writer.Write(flatZones[i].ZoneNumber);
             writer.Write(',');
-            writer.WriteLine(population[i]);
+            TMG.Functions.Utilities.WriteLine(writer, population[i], buffer);
         }
     }
 

--- a/Tasha/Emissions/GatherAutoEmissionsTripRecord.cs
+++ b/Tasha/Emissions/GatherAutoEmissionsTripRecord.cs
@@ -305,6 +305,7 @@ public class GatherAutoEmissionsTripRecord : IPostHouseholdIteration
 
     public void IterationFinished(int iteration, int totalIterations)
     {
+        Span<char> buffer = stackalloc char[32];
         using (var writer = new StreamWriter(SaveTo))
         {
             writer.WriteLine("HomeZone,Origin,Destination,StartHour,ExpandedPersons");
@@ -316,15 +317,15 @@ public class GatherAutoEmissionsTripRecord : IPostHouseholdIteration
                                  select rec)
             {
                 var index = entry.Key;
-                writer.Write(index.Home.ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, index.Home.ZoneNumber, buffer);
                 writer.Write(',');
-                writer.Write(index.Origin.ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, index.Origin.ZoneNumber, buffer);
                 writer.Write(',');
-                writer.Write(index.Destination.ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, index.Destination.ZoneNumber, buffer);
                 writer.Write(',');
-                writer.Write(index.StartHour);
+                TMG.Functions.Utilities.Write(writer, index.StartHour, buffer);
                 writer.Write(',');
-                writer.WriteLine(entry.Value);
+                TMG.Functions.Utilities.WriteLine(writer, entry.Value, buffer);
             }
         }
         Data.Clear();

--- a/Tasha/ModeChoiceEstimationHost.cs
+++ b/Tasha/ModeChoiceEstimationHost.cs
@@ -30,6 +30,7 @@ using static TMG.Functions.Utilities;
 using TMG.Input;
 using XTMF;
 using XTMF.Networking;
+using TMG.Functions;
 // ReSharper disable CompareOfFloatsByEqualityOperator
 
 namespace Tasha;
@@ -857,6 +858,7 @@ public class ModeChoiceEstimationHost : ITashaRuntime, IDisposable
         {
             var run = Population[index];
             bool writeHeader = !File.Exists(EvaluationFile);
+            Span<char> buffer = stackalloc char[32];
             while (true)
             {
                 try
@@ -879,13 +881,13 @@ public class ModeChoiceEstimationHost : ITashaRuntime, IDisposable
                     }
                     writer.Write(CurrentIteration);
                     writer.Write(',');
-                    writer.Write(run.Value);
+                    Write(writer, run.Value, buffer);
                     for (int i = 0; i < run.Parameters.Length; i++)
                     {
                         for (int j = 0; j < run.Parameters[i].Names.Length; j++)
                         {
                             writer.Write(',');
-                            writer.Write(run.Parameters[i].Current);
+                            Write(writer, run.Parameters[i].Current, buffer);
                         }
                     }
                     writer.WriteLine();
@@ -908,6 +910,7 @@ public class ModeChoiceEstimationHost : ITashaRuntime, IDisposable
     {
         var keys = att.Keys.ToList();
         writer.Write(keys.Count);
+        Span<char> buffer = stackalloc char[128];
         foreach (var key in keys)
         {
             writer.Write(key);

--- a/Tasha/Modes/BasicResultGeneration.cs
+++ b/Tasha/Modes/BasicResultGeneration.cs
@@ -17,6 +17,7 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -104,13 +105,13 @@ public sealed class BasicResultGeneration : IPostHousehold, IDisposable
                         builder.Append(',');
                         builder.Append((trip.ModesChosen == null || trip.ModesChosen.Length <= i || trip.ModesChosen[i] == null) ? "NONE" : trip.ModesChosen[i].ModeName);
                         builder.Append(',');
-                        builder.Append(expansionFactor);
+                        builder.Append(CultureInfo.InvariantCulture, $"{expansionFactor}");
                         builder.Append(',');
                         builder.Append((trip.TripStartTime.Hours * 100 + (trip.TripStartTime.Minutes / 30) * 30));
                         builder.Append(',');
-                        builder.Append(StraightLineDistance(trip.OriginalZone, trip.DestinationZone));
+                        builder.Append(CultureInfo.InvariantCulture, $"{StraightLineDistance(trip.OriginalZone, trip.DestinationZone)}");
                         builder.Append(',');
-                        builder.Append(ManhattanDistance(trip.OriginalZone, trip.DestinationZone));
+                        builder.Append(CultureInfo.InvariantCulture, $"{ManhattanDistance(trip.OriginalZone, trip.DestinationZone)}");
                         builder.AppendLine();
                     }
                 }

--- a/Tasha/Modes/ModeErrorMatrix.cs
+++ b/Tasha/Modes/ModeErrorMatrix.cs
@@ -21,6 +21,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Tasha.Common;
+using TMG.Functions;
 using XTMF;
 
 namespace Tasha.Modes;
@@ -230,14 +231,15 @@ public class ModeErrorMatrix : IPostHousehold
             }
             writer.WriteLine( "{0:0.##}%", 100 * ( correctTotal / (float)total ) );
 
+            Span<char> buffer = stackalloc char[32];
             if ( ComputeFitness )
             {
                 writer.Write( "Value," );
-                writer.WriteLine( Fitness );
+                TMG.Functions.Utilities.WriteLine(writer, Fitness, buffer);
                 writer.Write( "ZeroParam," );
-                writer.WriteLine( ZeroParamFitness );
+                TMG.Functions.Utilities.WriteLine(writer, ZeroParamFitness, buffer);
                 writer.Write( "Rho^2," );
-                writer.WriteLine( 1 - ( Fitness / ZeroParamFitness ) );
+                TMG.Functions.Utilities.WriteLine(writer, 1 - ( Fitness / ZeroParamFitness ), buffer);
                 // 2 lines of blank
                 var numberOfModes = Modes.Count;
                 writer.WriteLine( "\r\n" );
@@ -260,13 +262,13 @@ public class ModeErrorMatrix : IPostHousehold
                     writer.Write( ',' );
                     writer.Write( t.Mode );
                     writer.Write( ',' );
-                    writer.Write( t.Distance );
+                    TMG.Functions.Utilities.Write(writer, t.Distance, buffer);
                     writer.Write( ',' );
-                    writer.Write( t.HasTravelTime );
+                    TMG.Functions.Utilities.Write(writer, t.HasTravelTime, buffer);
                     writer.Write( ',' );
-                    writer.Write( t.OrginZone );
+                    TMG.Functions.Utilities.Write(writer, t.OrginZone, buffer);
                     writer.Write( ',' );
-                    writer.WriteLine( t.DestZone );
+                    TMG.Functions.Utilities.WriteLine(writer, t.DestZone, buffer);
                 }
             }
         }

--- a/Tasha/PopulationSynthesis/AssignWorkZonesFromResource.cs
+++ b/Tasha/PopulationSynthesis/AssignWorkZonesFromResource.cs
@@ -241,6 +241,7 @@ public class AssignWorkZonesFromResource : ICalculation<ITashaPerson, IZone>
 
             private void SaveHouseholdCategoryRecords()
             {
+                Span<char> buffer = stackalloc char[32];
                 if (SaveWorkerCategory != null && WorkerResults != null)
                 {
                     var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
@@ -251,11 +252,11 @@ public class AssignWorkZonesFromResource : ICalculation<ITashaPerson, IZone>
                         var zoneNumber = zones[i].ZoneNumber;
                         for (int cat = 0; cat < WorkerResults.Length; cat++)
                         {
-                            writer.Write(zoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zoneNumber, buffer);
                             writer.Write(',');
-                            writer.Write(cat + 1);
+                            TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                             writer.Write(',');
-                            writer.WriteLine(WorkerResults[cat][i]);
+                            TMG.Functions.Utilities.WriteLine(writer, WorkerResults[cat][i], buffer);
                         }
                     }
                 }

--- a/Tasha/PopulationSynthesis/AssignWorkZonesFromResourceWithoutReplacement.cs
+++ b/Tasha/PopulationSynthesis/AssignWorkZonesFromResourceWithoutReplacement.cs
@@ -296,6 +296,7 @@ public class AssignWorkZonesFromResourceWithoutReplacement : ICalculation<ITasha
 
             private void SaveHouseholdCategoryRecords()
             {
+                Span<char> buffer = stackalloc char[32];
                 if (SaveWorkerCategory != null && WorkerResults != null)
                 {
                     var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
@@ -306,11 +307,11 @@ public class AssignWorkZonesFromResourceWithoutReplacement : ICalculation<ITasha
                         var zoneNumber = zones[i].ZoneNumber;
                         for (int cat = 0; cat < WorkerResults.Length; cat++)
                         {
-                            writer.Write(zoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zoneNumber, buffer);
                             writer.Write(',');
-                            writer.Write(cat + 1);
+                            TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                             writer.Write(',');
-                            writer.WriteLine(WorkerResults[cat][i]);
+                            TMG.Functions.Utilities.WriteLine(writer, WorkerResults[cat][i], buffer);
                         }
                     }
                 }

--- a/Tasha/PopulationSynthesis/CreateZonalResidenceFromPopulation.cs
+++ b/Tasha/PopulationSynthesis/CreateZonalResidenceFromPopulation.cs
@@ -128,13 +128,14 @@ public sealed class CreateZonalResidenceFromPopulation : IPostHousehold
         var zones = _zones.GetFlatData();
         try
         {
+            Span<char> buffer = stackalloc char[32];
             using var writer = new StreamWriter(location);
             writer.WriteLine("Zone,Workers");
             for (int i = 0; i < data.Length; i++)
             {
-                writer.Write(zones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write(',');
-                writer.WriteLine(data[i]);
+                TMG.Functions.Utilities.WriteLine(writer, data[i], buffer);
             }
         }
         catch(IOException e)

--- a/Tasha/PopulationSynthesis/ExtractEmploymentData.cs
+++ b/Tasha/PopulationSynthesis/ExtractEmploymentData.cs
@@ -175,6 +175,7 @@ public class ExtractEmploymentData : IPostHousehold
 
     private void WriteTotalEmployment()
     {
+        Span<char> buffer = stackalloc char[32];
         if (TotalEmploymentByZone == null)
         {
             return;
@@ -186,7 +187,7 @@ public class ExtractEmploymentData : IPostHousehold
         {
             if (!ExternalPDs.Contains(flatZones[i].PlanningDistrict))
             {
-                writer.Write(flatZones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, flatZones[i].ZoneNumber, buffer);
                 writer.Write(',');
                 var acc = 0.0f;
                 for (int emp = 0; emp < _zonalEmployment.Length; emp++)
@@ -196,7 +197,7 @@ public class ExtractEmploymentData : IPostHousehold
                         acc += _zonalEmployment[emp][occ][i];
                     }
                 }
-                writer.WriteLine(acc);
+                TMG.Functions.Utilities.WriteLine(writer, acc, buffer);
             }
         }
     }
@@ -222,6 +223,7 @@ public class ExtractEmploymentData : IPostHousehold
         {
             return;
         }
+        Span<char> buffer = stackalloc char[32];
         var results = ComputeEmpOccRates();
         string dir = EmpOccRateDir;
         EnsureDirectory(dir);
@@ -239,9 +241,9 @@ public class ExtractEmploymentData : IPostHousehold
                         ? results[_pds.GetFlatIndex(zones[i].PlanningDistrict)] : results[i])[emp * 4 + occ];
                     if (value > 0.0)
                     {
-                        writer.Write(zoneNumber);
+                        TMG.Functions.Utilities.Write(writer, zoneNumber, buffer);
                         writer.Write(',');
-                        writer.WriteLine(value);
+                        TMG.Functions.Utilities.WriteLine(writer, value, buffer);
                     }
                 }
             }
@@ -317,6 +319,7 @@ public class ExtractEmploymentData : IPostHousehold
         {
             return;
         }
+        Span<char> buffer = stackalloc char[32];
         string dir = WorkAtHomeRateDir;
         EnsureDirectory(dir);
         var zones = _zones.GetFlatData();
@@ -344,9 +347,9 @@ public class ExtractEmploymentData : IPostHousehold
                         var index = _pds.GetFlatIndex(zones[i].PlanningDistrict);
                         if (totals[index] > 0)
                         {
-                            writer.Write(zones[i].ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                             writer.Write(',');
-                            writer.WriteLine(wah[index] / totals[index]);
+                            TMG.Functions.Utilities.WriteLine(writer, wah[index] / totals[index], buffer);
                         }
                     }
                 }
@@ -359,7 +362,7 @@ public class ExtractEmploymentData : IPostHousehold
                         var value = total <= 0.0f ? 0 : _zonalEmployment[emp + 2][occ][i] / total;
                         if (total > 0.0f)
                         {
-                            writer.Write(zones[i].ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                             writer.Write(',');
                             writer.WriteLine();
                         }
@@ -381,6 +384,7 @@ public class ExtractEmploymentData : IPostHousehold
         string dir = ExternalRateDir;
         EnsureDirectory(dir);
         var zones = _zones.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         for (int emp = 0; emp < 2; emp++)
         {
             for (int occ = 0; occ < 4; occ++)
@@ -413,9 +417,9 @@ public class ExtractEmploymentData : IPostHousehold
                         var index = _pds.GetFlatIndex(zones[i].PlanningDistrict);
                         if (totals[index] > 0)
                         {
-                            writer.Write(zones[i].ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                             writer.Write(',');
-                            writer.WriteLine(external[index] / totals[index]);
+                            TMG.Functions.Utilities.WriteLine(writer, external[index] / totals[index], buffer);
                         }
                     }
                 }
@@ -443,9 +447,9 @@ public class ExtractEmploymentData : IPostHousehold
                         }
                         if (total > 0)
                         {
-                            writer.Write(zones[workZone].ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, zones[workZone].ZoneNumber, buffer);
                             writer.Write(',');
-                            writer.WriteLine(external / total);
+                            TMG.Functions.Utilities.WriteLine(writer, external / total, buffer);
                         }
                     }
                 }
@@ -462,6 +466,7 @@ public class ExtractEmploymentData : IPostHousehold
         {
             return;
         }
+        Span<char> buffer = stackalloc char[32];
         string dir = ObservedLinkRateDir;
         var zones = _zones.GetFlatData();
         for (int emp = 0; emp < 2; emp++)
@@ -485,11 +490,11 @@ public class ExtractEmploymentData : IPostHousehold
                                     var value = _zonalWorkerCategories[emp][occ][homeZone][workZone][k];
                                     if (value > 0.0f)
                                     {
-                                        writer.Write(zones[homeZone].ZoneNumber);
+                                        TMG.Functions.Utilities.Write(writer, zones[homeZone].ZoneNumber, buffer);
                                         writer.Write(',');
-                                        writer.Write(zones[workZone].ZoneNumber);
+                                        TMG.Functions.Utilities.Write(writer, zones[workZone].ZoneNumber, buffer);
                                         writer.Write(',');
-                                        writer.WriteLine(value);
+                                        TMG.Functions.Utilities.WriteLine(writer, value, buffer);
                                     }
                                 }
                             }
@@ -512,6 +517,7 @@ public class ExtractEmploymentData : IPostHousehold
         string dir = WorkerCategoryDir;
         EnsureDirectory(dir);
         var zones = _zones.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         for (int emp = 0; emp < 2; emp++)
         {
             for (int occ = 0; occ < 4; occ++)
@@ -522,7 +528,6 @@ public class ExtractEmploymentData : IPostHousehold
                 {
                     if (!ExternalPDs.Contains(zones[homeZone].PlanningDistrict))
                     {
-
                         float wc0 = 0.0f, wc1 = 0.0f, wc2 = 0.0f;
                         for (int workZone = 0; workZone < zones.Length; workZone++)
                         {
@@ -540,15 +545,27 @@ public class ExtractEmploymentData : IPostHousehold
                             var zi = zones[homeZone].ZoneNumber;
                             if (wc0 > 0.0f)
                             {
-                                writer.Write(zi); writer.Write(','); writer.Write(1); writer.Write(','); writer.WriteLine(wc0 / total);
+                                TMG.Functions.Utilities.Write(writer, zi, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.Write(writer, 1, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.WriteLine(writer, wc0 / total, buffer);
                             }
                             if (wc1 > 0.0f)
                             {
-                                writer.Write(zi); writer.Write(','); writer.Write(2); writer.Write(','); writer.WriteLine(wc1 / total);
+                                TMG.Functions.Utilities.Write(writer, zi, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.Write(writer, 2, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.WriteLine(writer, wc1 / total, buffer);
                             }
                             if (wc2 > 0.0f)
                             {
-                                writer.Write(zi); writer.Write(','); writer.Write(3); writer.Write(','); writer.WriteLine(wc2 / total);
+                                TMG.Functions.Utilities.Write(writer, zi, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.Write(writer, 3, buffer);
+                                writer.Write(',');
+                                TMG.Functions.Utilities.WriteLine(writer, wc2 / total, buffer);
                             }
                         }
                     }
@@ -569,6 +586,7 @@ public class ExtractEmploymentData : IPostHousehold
         string dir = ZonalResidenceDir;
         EnsureDirectory(dir);
         var zones = _zones.GetFlatData();
+        Span<char> buffer = stackalloc char[32];
         for (int emp = 0; emp < 2; emp++)
         {
             for (int occ = 0; occ < 4; occ++)
@@ -579,9 +597,9 @@ public class ExtractEmploymentData : IPostHousehold
                 {
                     if (!ExternalPDs.Contains(zones[i].PlanningDistrict))
                     {
-                        writer.Write(zones[i].ZoneNumber);
+                        TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                         writer.Write(',');
-                        writer.WriteLine(_zonalResidence[emp][occ][i]);
+                        TMG.Functions.Utilities.WriteLine(writer, _zonalResidence[emp][occ][i], buffer);
                     }
                 }
             }

--- a/Tasha/PopulationSynthesis/ExtractHouseholdData.cs
+++ b/Tasha/PopulationSynthesis/ExtractHouseholdData.cs
@@ -149,19 +149,20 @@ public class ExtractHouseholdData : IPostHousehold
         {
             using StreamWriter writer = new(root.SaveFile.GetFileName());
             WriteHeader(root, writer);
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < EntryList.Count; i++)
             {
                 var entry = EntryList[i];
-                writer.Write(entry.PlanningDistrict);
+                TMG.Functions.Utilities.Write(writer, entry.PlanningDistrict, buffer);
                 writer.Write(',');
                 for (int j = 0; j < entry.AgeCategoryCount.Length; j++)
                 {
-                    writer.Write(entry.AgeCategoryCount[j]);
+                    TMG.Functions.Utilities.Write(writer, entry.AgeCategoryCount[j], buffer);
                     writer.Write(',');
                 }
-                writer.Write(entry.NumberOfCars);
+                TMG.Functions.Utilities.Write(writer, entry.NumberOfCars, buffer);
                 writer.Write(',');
-                writer.WriteLine(entry.ExpandedTotal);
+                TMG.Functions.Utilities.WriteLine(writer, entry.ExpandedTotal, buffer);
             }
         }
 

--- a/Tasha/PopulationSynthesis/ExtractPersonData.cs
+++ b/Tasha/PopulationSynthesis/ExtractPersonData.cs
@@ -146,12 +146,13 @@ public class ExtractPersonData : IPostHousehold
         {
             using StreamWriter writer = new(self.SaveFile.GetFileName());
             WriterHeader(writer);
+            Span<char> buffer = stackalloc char[32];
             for (int entry = 0; entry < EntryList.Count; entry++)
             {
                 var personType = EntryList[entry];
-                writer.Write(personType.PlaningDistrict);
+                TMG.Functions.Utilities.Write(writer, personType.PlaningDistrict, buffer);
                 writer.Write(',');
-                writer.Write(personType.AgeCat);
+                TMG.Functions.Utilities.Write(writer, personType.AgeCat, buffer);
                 writer.Write(',');
                 writer.Write(personType.Female ? 'F' : 'M');
                 writer.Write(',');
@@ -195,7 +196,7 @@ public class ExtractPersonData : IPostHousehold
                         break;
                 }
                 writer.Write(',');
-                writer.WriteLine(personType.ExpansionFactor);
+                TMG.Functions.Utilities.WriteLine(writer, personType.ExpansionFactor, buffer);
             }
         }
 

--- a/Tasha/PopulationSynthesis/PoRPoS.cs
+++ b/Tasha/PopulationSynthesis/PoRPoS.cs
@@ -128,13 +128,14 @@ public sealed class PoRPoS : IPreIteration
             {
                 using var writer = new StreamWriter(SaveFactors);
                 writer.WriteLine("Zone,Factor");
+                Span<char> buffer = stackalloc char[32];
                 foreach (var zoneFactor in from element in factors
                                            orderby element.Key ascending
                                            select new { Zone = zones[element.Key].ZoneNumber, Factor = element.Value })
                 {
-                    writer.Write(zoneFactor.Zone);
+                    TMG.Functions.Utilities.Write(writer, zoneFactor.Zone, buffer);
                     writer.Write(',');
-                    writer.WriteLine(zoneFactor.Factor);
+                    TMG.Functions.Utilities.WriteLine(writer, zoneFactor.Factor, buffer);
                 }
             }
         }

--- a/Tasha/PopulationSynthesis/PopulationRedistribution.cs
+++ b/Tasha/PopulationSynthesis/PopulationRedistribution.cs
@@ -363,13 +363,14 @@ public class PopulationRedistribution : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerForceDirectory));
         writer.WriteLine("Zone,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             if (workers[i] > 0)
             {
-                writer.Write(zones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write(',');
-                writer.WriteLine(workers[i]);
+                TMG.Functions.Utilities.WriteLine(writer, workers[i], buffer);
             }
         }
     }
@@ -378,6 +379,7 @@ public class PopulationRedistribution : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerCategoryDirectory));
         writer.WriteLine("Zone,WorkerCategory,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             var factor = 1.0f / workers[i].Sum();
@@ -393,11 +395,11 @@ public class PopulationRedistribution : IPostHousehold
             {
                 if (workers[i][cat] > 0)
                 {
-                    writer.Write(zones[i].ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(cat + 1);
+                    TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                     writer.Write(',');
-                    writer.WriteLine(workers[i][cat]);
+                    TMG.Functions.Utilities.WriteLine(writer, workers[i][cat], buffer);
                 }
             }
         }
@@ -473,6 +475,7 @@ public class PopulationRedistribution : IPostHousehold
         {
             householdID = 1;
             writer.WriteLine("HouseholdID,PersonNumber,Age,Sex,License,TransitPass,EmploymentStatus,Occupation,FreeParking,StudentStatus,EmploymentZone,SchoolZone,ExpansionFactor");
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < results.Length; i++)
             {
                 var households = householdRegions[i];
@@ -484,11 +487,11 @@ public class PopulationRedistribution : IPostHousehold
                     totalPerson += persons.Length;
                     for (int j = 0; j < persons.Length; j++)
                     {
-                        writer.Write(householdID);
+                        TMG.Functions.Utilities.Write(writer, householdID, buffer);
                         writer.Write(',');
-                        writer.Write((j + 1));
+                        TMG.Functions.Utilities.Write(writer, j + 1, buffer);
                         writer.Write(',');
-                        writer.Write(persons[j].Age);
+                        TMG.Functions.Utilities.Write(writer, persons[j].Age, buffer);
                         writer.Write(',');
                         writer.Write(persons[j].Female ? "F," : "M,");
                         writer.Write(persons[j].Licence ? "Y," : "N,");
@@ -605,7 +608,7 @@ public class PopulationRedistribution : IPostHousehold
                         // we don't save employment or school zone
                         if (IsExternal(workZone))
                         {
-                            writer.Write(workZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, workZone.ZoneNumber, buffer);
                         }
                         else
                         {
@@ -614,14 +617,14 @@ public class PopulationRedistribution : IPostHousehold
                         writer.Write(',');
                         if (IsExternal(schoolZone))
                         {
-                            writer.Write(schoolZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, schoolZone.ZoneNumber, buffer);
                         }
                         else
                         {
                             writer.Write('0');
                         }
                         writer.Write(',');
-                        writer.WriteLine(persons[j].ExpansionFactor);
+                        TMG.Functions.Utilities.WriteLine(writer, persons[j].ExpansionFactor, buffer);
                     }
                     householdID++;
                 }
@@ -662,6 +665,7 @@ public class PopulationRedistribution : IPostHousehold
         int householdID = 1;
         using var writer = new StreamWriter(HouseholdFile);
         writer.WriteLine("HouseholdID,Zone,ExpansionFactor,DwellingType,NumberOfPersons,NumberOfVehicles");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < results.Length; i++)
         {
             var households = householdsByRegion[i];
@@ -669,16 +673,16 @@ public class PopulationRedistribution : IPostHousehold
             {
                 var zone = record.Key;
                 var household = households[record.Value];
-                writer.Write(householdID);
+                TMG.Functions.Utilities.Write(writer, householdID, buffer);
                 writer.Write(',');
-                writer.Write(zones[zone]);
+                TMG.Functions.Utilities.Write(writer, zones[zone], buffer);
                 // the expansion factor is always 1
                 writer.Write(",1,");
-                writer.Write((int)household.DwellingType);
+                TMG.Functions.Utilities.Write(writer, (int)household.DwellingType, buffer);
                 writer.Write(',');
-                writer.Write(household.Persons.Length);
+                TMG.Functions.Utilities.Write(writer, household.Persons.Length, buffer);
                 writer.Write(',');
-                writer.WriteLine(household.Vehicles.Length);
+                TMG.Functions.Utilities.WriteLine(writer, household.Vehicles.Length, buffer);
                 householdID++;
             }
         }

--- a/Tasha/PopulationSynthesis/ReplicationByZoneDensity.cs
+++ b/Tasha/PopulationSynthesis/ReplicationByZoneDensity.cs
@@ -337,13 +337,14 @@ public class ReplicationByZoneDensity : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerForceDirectory));
         writer.WriteLine("Zone,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             if (workers[i] > 0)
             {
-                writer.Write(zones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write(',');
-                writer.WriteLine(workers[i]);
+                TMG.Functions.Utilities.WriteLine(writer, workers[i], buffer);
             }
         }
     }
@@ -352,6 +353,7 @@ public class ReplicationByZoneDensity : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerCategoryDirectory));
         writer.WriteLine("Zone,WorkerCategory,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             var factor = 1.0f / workers[i].Sum();
@@ -367,11 +369,11 @@ public class ReplicationByZoneDensity : IPostHousehold
             {
                 if (workers[i][cat] > 0)
                 {
-                    writer.Write(zones[i].ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(cat + 1);
+                    TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                     writer.Write(',');
-                    writer.WriteLine(workers[i][cat]);
+                    TMG.Functions.Utilities.WriteLine(writer, workers[i][cat], buffer);
                 }
             }
         }
@@ -447,6 +449,7 @@ public class ReplicationByZoneDensity : IPostHousehold
         {
             householdID = 1;
             writer.WriteLine("HouseholdID,PersonNumber,Age,Sex,License,TransitPass,EmploymentStatus,Occupation,FreeParking,StudentStatus,EmploymentZone,SchoolZone,ExpansionFactor");
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < results.Length; i++)
             {
                 foreach (var record in results[i])
@@ -458,11 +461,11 @@ public class ReplicationByZoneDensity : IPostHousehold
                     for (int j = 0; j < persons.Length; j++)
                     {
                         totalPerson++;
-                        writer.Write(householdID);
+                        TMG.Functions.Utilities.Write(writer, householdID, buffer);
                         writer.Write(',');
-                        writer.Write((j + 1));
+                        TMG.Functions.Utilities.Write(writer, (j + 1), buffer);
                         writer.Write(',');
-                        writer.Write(persons[j].Age);
+                        TMG.Functions.Utilities.Write(writer, persons[j].Age, buffer);
                         writer.Write(',');
                         writer.Write(persons[j].Female ? "F," : "M,");
                         writer.Write(persons[j].Licence ? "Y," : "N,");
@@ -579,7 +582,7 @@ public class ReplicationByZoneDensity : IPostHousehold
                         // we don't save employment or school zone
                         if (IsExternal(workZone))
                         {
-                            writer.Write(workZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, workZone.ZoneNumber, buffer);
                         }
                         else
                         {
@@ -588,7 +591,7 @@ public class ReplicationByZoneDensity : IPostHousehold
                         writer.Write(',');
                         if (IsExternal(schoolZone))
                         {
-                            writer.Write(schoolZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, schoolZone.ZoneNumber, buffer);
                         }
                         else
                         {
@@ -636,6 +639,7 @@ public class ReplicationByZoneDensity : IPostHousehold
         int householdID = 1;
         using var writer = new StreamWriter(HouseholdFile);
         writer.WriteLine("HouseholdID,Zone,ExpansionFactor,DwellingType,NumberOfPersons,NumberOfVehicles");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < results.Length; i++)
         {
             foreach (var record in results[i])
@@ -646,13 +650,13 @@ public class ReplicationByZoneDensity : IPostHousehold
                 writer.Write(',');
                 writer.Write(zones[zone]);
                 writer.Write(",");
-                writer.Write(InvHouseholdExpansion);
+                TMG.Functions.Utilities.Write(writer, InvHouseholdExpansion, buffer);
                 writer.Write(",");
-                writer.Write((int)household.DwellingType);
+                TMG.Functions.Utilities.Write(writer, (int)household.DwellingType, buffer);
                 writer.Write(',');
-                writer.Write(household.Persons.Length);
+                TMG.Functions.Utilities.Write(writer, household.Persons.Length, buffer);
                 writer.Write(',');
-                writer.WriteLine(household.Vehicles.Length);
+                TMG.Functions.Utilities.WriteLine(writer, household.Vehicles.Length, buffer);
                 householdID++;
             }
         }

--- a/Tasha/PopulationSynthesis/TTSPopulationReplicationForcast.cs
+++ b/Tasha/PopulationSynthesis/TTSPopulationReplicationForcast.cs
@@ -304,13 +304,14 @@ public class TTSPopulationReplicationForcast : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerForceDirectory));
         writer.WriteLine("Zone,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             if (workers[i] > 0)
             {
-                writer.Write(zones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write(',');
-                writer.WriteLine(workers[i]);
+                TMG.Functions.Utilities.WriteLine(writer, workers[i], buffer);
             }
         }
     }
@@ -319,6 +320,7 @@ public class TTSPopulationReplicationForcast : IPostHousehold
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerCategoryDirectory));
         writer.WriteLine("Zone,WorkerCategory,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             var factor = 1.0f / workers[i].Sum();
@@ -334,11 +336,11 @@ public class TTSPopulationReplicationForcast : IPostHousehold
             {
                 if (workers[i][cat] > 0)
                 {
-                    writer.Write(zones[i].ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(cat + 1);
+                    TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                     writer.Write(',');
-                    writer.WriteLine(workers[i][cat]);
+                    TMG.Functions.Utilities.WriteLine(writer, workers[i][cat], buffer);
                 }
             }
         }
@@ -414,6 +416,7 @@ public class TTSPopulationReplicationForcast : IPostHousehold
         {
             householdID = 1;
             writer.WriteLine("HouseholdID,PersonNumber,Age,Sex,License,TransitPass,EmploymentStatus,Occupation,FreeParking,StudentStatus,EmploymentZone,SchoolZone,ExpansionFactor");
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < results.Length; i++)
             {
                 var households = pds[i].Households;
@@ -425,11 +428,11 @@ public class TTSPopulationReplicationForcast : IPostHousehold
                     for (int j = 0; j < persons.Length; j++)
                     {
                         totalPerson++;
-                        writer.Write(householdID);
+                        TMG.Functions.Utilities.Write(writer, householdID, buffer);
                         writer.Write(',');
-                        writer.Write((j + 1));
+                        TMG.Functions.Utilities.Write(writer, (j + 1), buffer);
                         writer.Write(',');
-                        writer.Write(persons[j].Age);
+                        TMG.Functions.Utilities.Write(writer, persons[j].Age, buffer);
                         writer.Write(',');
                         writer.Write(persons[j].Female ? "F," : "M,");
                         writer.Write(persons[j].Licence ? "Y," : "N,");
@@ -566,7 +569,7 @@ public class TTSPopulationReplicationForcast : IPostHousehold
                         // we don't save employment or school zone
                         if (IsExternal(workZone))
                         {
-                            writer.Write(workZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, workZone.ZoneNumber, buffer);
                         }
                         else
                         {
@@ -575,14 +578,14 @@ public class TTSPopulationReplicationForcast : IPostHousehold
                         writer.Write(',');
                         if (IsExternal(schoolZone))
                         {
-                            writer.Write(schoolZone.ZoneNumber);
+                            TMG.Functions.Utilities.Write(writer, schoolZone.ZoneNumber, buffer);
                         }
                         else
                         {
                             writer.Write('0');
                         }
                         writer.Write(',');
-                        writer.WriteLine(persons[j].ExpansionFactor);
+                        TMG.Functions.Utilities.WriteLine(writer, persons[j].ExpansionFactor, buffer);
                     }
                     householdID++;
                 }
@@ -620,6 +623,7 @@ public class TTSPopulationReplicationForcast : IPostHousehold
         int householdID = 1;
         using var writer = new StreamWriter(HouseholdFile);
         writer.WriteLine("HouseholdID,Zone,ExpansionFactor,DwellingType,NumberOfPersons,NumberOfVehicles,IncomeLevel");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < results.Length; i++)
         {
             var households = pds[i].Households;
@@ -631,15 +635,15 @@ public class TTSPopulationReplicationForcast : IPostHousehold
                 writer.Write(',');
                 writer.Write(zones[zone]);
                 writer.Write(",");
-                writer.Write(_invHouseholdExpansion);
+                TMG.Functions.Utilities.Write(writer, _invHouseholdExpansion, buffer);
                 writer.Write(",");
-                writer.Write((int)household.DwellingType);
+                TMG.Functions.Utilities.Write(writer, (int)household.DwellingType, buffer);
                 writer.Write(',');
-                writer.Write(household.Persons.Length);
+                TMG.Functions.Utilities.Write(writer, household.Persons.Length, buffer);
                 writer.Write(',');
-                writer.Write(household.Vehicles.Length);
+                TMG.Functions.Utilities.Write(writer, household.Vehicles.Length, buffer);
                 writer.Write(',');
-                writer.WriteLine(household.IncomeClass);
+                TMG.Functions.Utilities.WriteLine(writer, household.IncomeClass, buffer);
                 householdID++;
             }
         }

--- a/Tasha/PopulationSynthesis/UpdatePopulationRatesByZone.cs
+++ b/Tasha/PopulationSynthesis/UpdatePopulationRatesByZone.cs
@@ -90,13 +90,14 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
 
     private void WritePersonData(ITashaHousehold household, ITashaPerson person, int workerCategory)
     {
+        Span<char> buffer = stackalloc char[32];
         var zoneArray = Root.ZoneSystem.ZoneArray;
         var zone = zoneArray.GetFlatIndex(household.HomeZone.ZoneNumber);
-        Writer.Write(household.HouseholdId);
+        TMG.Functions.Utilities.Write(Writer, household.HouseholdId, buffer);
         Writer.Write(',');
-        Writer.Write(person.Id);
+        TMG.Functions.Utilities.Write(Writer, person.Id, buffer);
         Writer.Write(',');
-        Writer.Write(person.Age);
+        TMG.Functions.Utilities.Write(Writer, person.Age, buffer);
         Writer.Write(',');
         Writer.Write(person.Female ? "F," : "M,");
         Writer.Write(person.Licence ? "Y," : "N,");
@@ -213,7 +214,7 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
         // we don't save employment or school zone
         if (IsExternal(workZone))
         {
-            Writer.Write(workZone.ZoneNumber);
+            TMG.Functions.Utilities.Write(Writer, workZone.ZoneNumber, buffer);
         }
         else
         {
@@ -222,14 +223,14 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
         Writer.Write(',');
         if (IsExternal(schoolZone))
         {
-            Writer.Write(schoolZone.ZoneNumber);
+            TMG.Functions.Utilities.Write(Writer, schoolZone.ZoneNumber, buffer);
         }
         else
         {
             Writer.Write('0');
         }
         Writer.Write(',');
-        Writer.WriteLine(person.ExpansionFactor);
+        TMG.Functions.Utilities.WriteLine(Writer, person.ExpansionFactor, buffer);
     }
 
     private string BuildFileName(Occupation occ, TTSEmploymentStatus empStat)
@@ -272,13 +273,14 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat));
         writer.WriteLine("Zone,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             if (workers[i] > 0)
             {
-                writer.Write(zones[i].ZoneNumber);
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write(',');
-                writer.WriteLine(workers[i]);
+                TMG.Functions.Utilities.WriteLine(writer, workers[i], buffer);
             }
         }
     }
@@ -314,6 +316,7 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
     {
         using StreamWriter writer = new(BuildFileName(occupation, empStat, WorkerCategoryDirectory));
         writer.WriteLine("Zone,WorkerCategory,Persons");
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < workers.Length; i++)
         {
             var factor = 1.0f / workers[i].Sum();
@@ -329,11 +332,11 @@ public sealed class UpdatePopulationRatesByZone : IPostHousehold, IDisposable
             {
                 if (workers[i][cat] > 0)
                 {
-                    writer.Write(zones[i].ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(cat + 1);
+                    TMG.Functions.Utilities.Write(writer, cat + 1, buffer);
                     writer.Write(',');
-                    writer.WriteLine(workers[i][cat]);
+                    TMG.Functions.Utilities.WriteLine(writer, workers[i][cat], buffer);
                 }
             }
         }

--- a/Tasha/Scheduler/ActivityDistribution.cs
+++ b/Tasha/Scheduler/ActivityDistribution.cs
@@ -83,18 +83,19 @@ internal static class ActivityDistribution
     {
         var zones = zoneArray.GetFlatData();
         string csvFileName = Path.GetTempFileName();
+        Span<char> buffer = stackalloc char[256];
         using ( StreamWriter writer = new( csvFileName ) )
         {
             writer.WriteLine( "Zone,Retail Level,Other Level,Work Level" );
             for ( int i = 0; i < zones.Length; i++ )
             {
-                writer.Write( zones[i].ZoneNumber );
+                TMG.Functions.Utilities.Write(writer, zones[i].ZoneNumber, buffer);
                 writer.Write( ',' );
-                writer.Write( zones[i].RetailActivityLevel );
+                TMG.Functions.Utilities.Write(writer, zones[i].RetailActivityLevel, buffer);
                 writer.Write( ',' );
-                writer.Write( zones[i].OtherActivityLevel );
+                TMG.Functions.Utilities.Write(writer, zones[i].OtherActivityLevel, buffer);
                 writer.Write( ',' );
-                writer.WriteLine( zones[i].WorkActivityLevel );
+                TMG.Functions.Utilities.WriteLine(writer, zones[i].WorkActivityLevel, buffer);
             }
         }
         SparseZoneCreator creator = new( zones.Last().ZoneNumber + 1, 3 );

--- a/Tasha/Scheduler/MakingNumberOfAdultDistributions.cs
+++ b/Tasha/Scheduler/MakingNumberOfAdultDistributions.cs
@@ -475,6 +475,7 @@ public class MakingNumberOfAdultDistributions : ITashaRuntime
                 //NO HEADER
                 //DistributionID,NumberOfAdults,ExpandedSum,Probability,CDF
                 using StreamWriter writer = new(ResultFile.GetFilePath());
+                Span<char> buffer = stackalloc char[32];
                 for (int dist = 0; dist < combinedResults.Length; dist++)
                 {
                     var cdf = 0.0;
@@ -494,15 +495,15 @@ public class MakingNumberOfAdultDistributions : ITashaRuntime
                     {
                         var probability = combinedResults[dist][i] * factor;
                         cdf += probability;
-                        writer.Write(dist);
+                        TMG.Functions.Utilities.Write(writer, dist, buffer);
                         writer.Write(',');
-                        writer.Write(i);
+                        TMG.Functions.Utilities.Write(writer, i, buffer);
                         writer.Write(',');
-                        writer.Write(combinedResults[dist][i]);
+                        TMG.Functions.Utilities.Write(writer, combinedResults[dist][i], buffer);
                         writer.Write(',');
-                        writer.Write(combinedResults[dist][i] * factor);
+                        TMG.Functions.Utilities.Write(writer, combinedResults[dist][i] * factor, buffer);
                         writer.Write(',');
-                        writer.WriteLine(cdf);
+                        TMG.Functions.Utilities.WriteLine(writer, cdf, buffer);
                     }
                 }
             } );

--- a/Tasha/StationAccess/ComputeStationCapacityFactor.cs
+++ b/Tasha/StationAccess/ComputeStationCapacityFactor.cs
@@ -135,19 +135,20 @@ public class ComputeStationCapacityFactor : IPostIteration
             var currentFraction = iteration > 0 ? iteration / (1.0f + iteration) : 1.0f;
             using var writer = new StreamWriter(CapacityFactorOutput);
             writer.WriteLine("Zone,Factor,Demand,Capacity");
+            Span<char> buffer = stackalloc char[32];
             for (int i = 0; i < accessStationCounts.Length; i++)
             {
                 float stationCapacity = capacity[zoneIndexForStation[i]];
                 if (ComputeStationCapacityFactor(previousFraction, currentFraction, accessStationCounts[i], stationCapacity, CapacityFactors[i], out float capacityFactor))
                 {
                     CapacityFactors[i] = capacityFactor;
-                    writer.Write(zones[zoneIndexForStation[i]].ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, zones[zoneIndexForStation[i]].ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(capacityFactor);
+                    TMG.Functions.Utilities.Write(writer, capacityFactor, buffer);
                     writer.Write(',');
-                    writer.Write(accessStationCounts[i]);
+                    TMG.Functions.Utilities.Write(writer, accessStationCounts[i], buffer);
                     writer.Write(',');
-                    writer.WriteLine(CapacityMultiplier * stationCapacity);
+                    TMG.Functions.Utilities.WriteLine(writer, CapacityMultiplier * stationCapacity, buffer);
                 }
                 else
                 {

--- a/Tasha/XTMFModeChoice/ModeErrorMatrix.cs
+++ b/Tasha/XTMFModeChoice/ModeErrorMatrix.cs
@@ -234,6 +234,7 @@ public class ModeErrorMatrix : IPostHousehold
         var correctTotal = 0.0f;
         var columnTotals = new float[numModes];
         var total = 0.0f;
+        Span<char> buffer = stackalloc char[32];
         using (StreamWriter writer = new(FileName))
         {
             // print the header
@@ -253,7 +254,7 @@ public class ModeErrorMatrix : IPostHousehold
                 {
                     var val = Observations[i][j];
                     writer.Write(',');
-                    writer.Write(val);
+                    TMG.Functions.Utilities.Write(writer, val, buffer);
                     columnTotals[i] += val;
                     rowTotal += val;
                     if (i == j)
@@ -263,15 +264,15 @@ public class ModeErrorMatrix : IPostHousehold
                     total += val;
                 }
                 writer.Write(',');
-                writer.WriteLine(rowTotal);
+                TMG.Functions.Utilities.WriteLine(writer, rowTotal, buffer);
             }
             writer.Write("Column Total,");
             for (int i = 0; i < numModes; i++)
             {
-                writer.Write(columnTotals[i]);
+                TMG.Functions.Utilities.Write(writer, columnTotals[i], buffer);
                 writer.Write(',');
             }
-            writer.WriteLine(correctTotal);
+            TMG.Functions.Utilities.WriteLine(writer, correctTotal, buffer);
 
             // NOW COMPUTE THE %
             writer.Write("Pred\\Real%");
@@ -289,15 +290,15 @@ public class ModeErrorMatrix : IPostHousehold
                 for (int i = 0; i < numModes; i++)
                 {
                     writer.Write(',');
-                    writer.Write("{0:0.##}%", 100 * ((Observations[i][j]) / total));
+                    TMG.Functions.Utilities.Write(writer, 100 * ((Observations[i][j]) / total), "{0:0.##}%", buffer);
                     rowTotal += Observations[i][j];
                 }
-                writer.WriteLine(",{0:0.##}%", 100 * (rowTotal / total));
+                TMG.Functions.Utilities.WriteLine(writer, 100 * (rowTotal / total), ",{0:0.##}%", buffer);
             }
             writer.Write("Column Total,");
             for (int i = 0; i < numModes; i++)
             {
-                writer.Write("{0:0.##}%", 100 * (columnTotals[i] / total));
+                TMG.Functions.Utilities.Write(writer, 100 * (columnTotals[i] / total), "{0:0.##}%", buffer);
                 writer.Write(',');
             }
             writer.WriteLine("{0:0.##}%", 100 * (correctTotal / total));
@@ -305,11 +306,11 @@ public class ModeErrorMatrix : IPostHousehold
             if (ComputeFitness)
             {
                 writer.Write("Value,");
-                writer.WriteLine(Fitness);
+                TMG.Functions.Utilities.WriteLine(writer, Fitness, buffer);
                 writer.Write("ZeroParam,");
-                writer.WriteLine(ZeroParamFitness);
+                TMG.Functions.Utilities.WriteLine(writer, ZeroParamFitness, buffer);
                 writer.Write("Rho^2,");
-                writer.WriteLine(1 - (Fitness / ZeroParamFitness));
+                TMG.Functions.Utilities.WriteLine(writer, 1 - (Fitness / ZeroParamFitness), buffer);
                 // 2 lines of blank
                 var numberOfModes = Modes.Count;
                 writer.WriteLine("\r\n");
@@ -318,29 +319,29 @@ public class ModeErrorMatrix : IPostHousehold
                 {
                     writer.Write(Modes[i].ModeName);
                     writer.Write(',');
-                    writer.WriteLine(BadTrips[i]);
+                    TMG.Functions.Utilities.WriteLine(writer, BadTrips[i], buffer);
                 }
                 writer.WriteLine("Missing Trips");
-                writer.WriteLine(MissingTrips);
-                writer.WriteLine("Invaid Trips");
+                TMG.Functions.Utilities.WriteLine(writer, MissingTrips, buffer);
+                writer.WriteLine("Invalid Trips");
                 writer.WriteLine("HHLD,Person,Trip#,Mode,Distance,HasTravelTime,OriginZone,DestZone");
                 while (BadTripsQueue.TryDequeue(out BadTripEntry t))
                 {
-                    writer.Write(t.HHLD);
+                    TMG.Functions.Utilities.Write(writer, t.HHLD, buffer);
                     writer.Write(',');
-                    writer.Write(t.PersonID);
+                    TMG.Functions.Utilities.Write(writer, t.PersonID, buffer);
                     writer.Write(',');
-                    writer.Write(t.TripID);
+                    TMG.Functions.Utilities.Write(writer, t.TripID, buffer);
                     writer.Write(',');
-                    writer.Write(t.Mode);
+                    TMG.Functions.Utilities.Write(writer, t.Mode, buffer);
                     writer.Write(',');
-                    writer.Write(t.Distance);
+                    TMG.Functions.Utilities.Write(writer, t.Distance, buffer);
                     writer.Write(',');
-                    writer.Write(t.HasTravelTime);
+                    TMG.Functions.Utilities.Write(writer, t.HasTravelTime, buffer);
                     writer.Write(',');
-                    writer.Write(t.OrginZone);
+                    TMG.Functions.Utilities.Write(writer, t.OrginZone, buffer);
                     writer.Write(',');
-                    writer.WriteLine(t.DestZone);
+                    TMG.Functions.Utilities.WriteLine(writer, t.DestZone, buffer);
                 }
             }
         }

--- a/TorontoHouseholds/HouseholdLoader.cs
+++ b/TorontoHouseholds/HouseholdLoader.cs
@@ -819,6 +819,7 @@ public sealed class HouseholdLoader : IDataLoader<ITashaHousehold>, IDisposable
             TripDump.WriteLine("HouseholdID,PersonID,TripChain,TripNumber,StartTime,ObservedMode,OriginRegion,DesitinationRegion,OriginPD,DestinationPD,OriginZone,DestinationZone,Activity,Expansion Factor");
         }
         var writer = TripDump;
+        Span<char> buffer = stackalloc char[32];
         for (int i = 0; i < h.Persons.Length; i++)
         {
             var person = (Person)h.Persons[i];
@@ -829,39 +830,39 @@ public sealed class HouseholdLoader : IDataLoader<ITashaHousehold>, IDisposable
                 {
                     var trip = (Trip)tc.Trips[k];
                     var obsMode = (ITashaMode)trip["ObservedMode"];
-                    writer.Write(h.HouseholdId);
+                    TMG.Functions.Utilities.Write(writer, h.HouseholdId, buffer);
                     writer.Write(',');
                     // person number
-                    writer.Write(i);
+                    TMG.Functions.Utilities.Write(writer, i, buffer);
                     writer.Write(',');
                     //trip chain number
-                    writer.Write(j);
+                    TMG.Functions.Utilities.Write(writer, j, buffer);
                     writer.Write(',');
                     // trip number
-                    writer.Write(k);
+                    TMG.Functions.Utilities.Write(writer, k, buffer);
                     writer.Write(',');
                     writer.Write(trip.TripStartTime);
                     writer.Write(',');
                     writer.Write(obsMode == null ? "NO_OBS" : obsMode.ModeName);
                     writer.Write(',');
                     //region
-                    writer.Write(trip.OriginalZone.RegionNumber);
+                    TMG.Functions.Utilities.Write(writer, trip.OriginalZone.RegionNumber, buffer);
                     writer.Write(',');
-                    writer.Write(trip.DestinationZone.RegionNumber);
+                    TMG.Functions.Utilities.Write(writer, trip.DestinationZone.RegionNumber, buffer);
                     writer.Write(',');
                     //pd
-                    writer.Write(trip.OriginalZone.PlanningDistrict);
+                    TMG.Functions.Utilities.Write(writer, trip.OriginalZone.PlanningDistrict, buffer);
                     writer.Write(',');
-                    writer.Write(trip.DestinationZone.PlanningDistrict);
+                    TMG.Functions.Utilities.Write(writer, trip.DestinationZone.PlanningDistrict, buffer);
                     writer.Write(',');
                     //zone
-                    writer.Write(trip.OriginalZone.ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, trip.OriginalZone.ZoneNumber, buffer);
                     writer.Write(',');
-                    writer.Write(trip.DestinationZone.ZoneNumber);
+                    TMG.Functions.Utilities.Write(writer, trip.DestinationZone.ZoneNumber, buffer);
                     writer.Write(',');
                     writer.Write(Enum.GetName(typeof(Activity), trip.Purpose));
                     writer.Write(',');
-                    writer.WriteLine(person.ExpansionFactor);
+                    TMG.Functions.Utilities.WriteLine(writer, person.ExpansionFactor, buffer);
                 }
             }
         }

--- a/TorontoHouseholds/TorontoHouseholds.csproj
+++ b/TorontoHouseholds/TorontoHouseholds.csproj
@@ -54,6 +54,7 @@
 		<Optimize>true</Optimize>
 	</PropertyGroup>
 	<ItemGroup>
+		<ProjectReference Include="..\Code\TMG.Functions\TMG.Functions.csproj" />
 		<ProjectReference Include="..\Code\TMGInterfaces\TMGInterfaces.csproj" />
 		<ProjectReference Include="..\Code\XTMFInterfaces\XTMFInterfaces.csproj" />
 		<ProjectReference Include="..\Datastructure\Datastructure.csproj" />


### PR DESCRIPTION
Currently parameters are being saved in their local culture.  This runs into a problem when moving models between deferent machines, commas in floating point numbers for French will be instead skipped and a large integer will be loaded in its place when loading the model system on an English system.

