### PR TITLE
Fixed Microsim Facilitate Passenger

### DIFF
--- a/Code/Tasha.Validation/ModeChoice/ExtractPersonalAndTripRecords.cs
+++ b/Code/Tasha.Validation/ModeChoice/ExtractPersonalAndTripRecords.cs
@@ -1368,7 +1368,7 @@ public sealed class ExtractPersonalAndTripRecords : IPostHouseholdIteration, IDi
                 writer.Write(',');
                 TMG.Functions.Utilities.Write(writer, passengerTrip.DriverTripID, buffer);
                 writer.Write(',');
-                TMG.Functions.Utilities.Write(writer, passengerTrip.Weight, buffer);
+                TMG.Functions.Utilities.WriteLine(writer, passengerTrip.Weight, buffer);
             }
         }
         if (CompressResults)


### PR DESCRIPTION
This patch fixes the regression where all passenger records were saved on the same line.
