### PR TITLE
Update branding to XTMF Version 1.15

### DIFF
--- a/Code/XTMF.Gui/MainWindow.xaml
+++ b/Code/XTMF.Gui/MainWindow.xaml
@@ -29,7 +29,7 @@
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:dragablz="http://dragablz.net/winfx/xaml/dragablz"
         xmlns:dockablz="http://dragablz.net/winfx/xaml/dockablz"
-        Title="XTMF Version 1.14" Height="768" Width="1024" IsHitTestVisible="True"
+        Title="XTMF Version 1.15" Height="768" Width="1024" IsHitTestVisible="True"
         Icon="/XTMF.Gui;component/Images/XTMF_icon_2.ico" MinHeight="700" MinWidth="750"
         Name="XtmfWindow"
         PreviewKeyDown="MainWindow_OnPreviewKeyDown"

--- a/Code/XTMF.Gui/Properties/AssemblyInfo.cs
+++ b/Code/XTMF.Gui/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Windows;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("XTMF.Gui.1.14")]
+[assembly: AssemblyTitle("XTMF.Gui.1.15")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("University of Toronto")]
-[assembly: AssemblyProduct("XTMF.Gui.1.14")]
-[assembly: AssemblyCopyright("Copyright © University of Toronto 2011-2024")]
+[assembly: AssemblyProduct("XTMF.Gui.1.15")]
+[assembly: AssemblyCopyright("Copyright © University of Toronto 2011-2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -49,5 +49,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.14.0")]
-[assembly: AssemblyFileVersion("1.14.0")]
+[assembly: AssemblyVersion("1.15.0")]
+[assembly: AssemblyFileVersion("1.15.0")]

--- a/Code/XTMF/Properties/AssemblyInfo.cs
+++ b/Code/XTMF/Properties/AssemblyInfo.cs
@@ -4,12 +4,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("XTMF1.12")]
+[assembly: AssemblyTitle("XTMF1.15")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
-[assembly: AssemblyProduct("XTMF1.12")]
-[assembly: AssemblyCopyright("University of Toronto 2011-2023")]
+[assembly: AssemblyProduct("XTMF1.15")]
+[assembly: AssemblyCopyright("University of Toronto 2011-2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.12.0.0")]
-[assembly: AssemblyFileVersion("1.12.0.0")]
+[assembly: AssemblyVersion("1.15.0.0")]
+[assembly: AssemblyFileVersion("1.15.0.0")]

--- a/Code/XTMFInterfaces/Properties/AssemblyInfo.cs
+++ b/Code/XTMFInterfaces/Properties/AssemblyInfo.cs
@@ -25,9 +25,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle( "XTMFInterfaces" )]
 [assembly: AssemblyDescription( "" )]
 [assembly: AssemblyConfiguration( "" )]
-[assembly: AssemblyCompany( "Microsoft" )]
+[assembly: AssemblyCompany( "University of Toronto" )]
 [assembly: AssemblyProduct( "XTMFInterfaces" )]
-[assembly: AssemblyCopyright( "Copyright © Microsoft 2011" )]
+[assembly: AssemblyCopyright("Copyright © University of Toronto 2011-2025")]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 


### PR DESCRIPTION
Update version numbers to XTMF 1.15.

Also fixes an old copywrite for XTMFInterfaces.