### PR TITLE
Trim Project names

### DIFF
--- a/Code/XTMF/Controller/ProjectController.cs
+++ b/Code/XTMF/Controller/ProjectController.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Xml.Linq;
 
 namespace XTMF;
 

--- a/Code/XTMF/Controller/ProjectController.cs
+++ b/Code/XTMF/Controller/ProjectController.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Linq;
 
 namespace XTMF;
 
@@ -99,6 +100,7 @@ public class ProjectController
     /// <returns>True if the clone succeeded,</returns>
     public bool CloneProject(Project toClone, string name, ref string error)
     {
+        name = name?.Trim();
         if (!Project.ValidateProjectName(name))
         {
             error = "The project name was invalid!";
@@ -136,6 +138,7 @@ public class ProjectController
     /// <returns>True if the rename succeeded, false otherwise.</returns>
     public bool RenameProject(Project project, string newName, ref string error)
     {
+        newName = newName?.Trim();
         lock (EditingSessionLock)
         {
             if (!((ProjectRepository)Runtime.Configuration.ProjectRepository).RenameProject(project, newName, ref error))
@@ -203,6 +206,7 @@ public class ProjectController
     /// <returns>The loaded project</returns>
     public Project Load(string name, ref string error)
     {
+        name = name?.Trim();
         lock (EditingSessionLock)
         {
             var loadedProject = (from project in Runtime.Configuration.ProjectRepository.Projects
@@ -224,6 +228,7 @@ public class ProjectController
     /// <returns>The loaded project</returns>
     public Project LoadOrCreate(string name, ref string error)
     {
+        name = name?.Trim();
         lock (EditingSessionLock)
         {
             Project alreadyLoaded;
@@ -295,6 +300,7 @@ public class ProjectController
     {
         Project project;
         string ignore = null;
+        name = name?.Trim();
         if ((project = Load(name, ref ignore)) != null)
         {
             return DeleteProject(project, ref error);


### PR DESCRIPTION
Currently if you have a project with a name that ends with whitespace Windows will have problems accessing that folder.  This patch will just trim all whitespace off the front and end of all new, and renamed project names.
