### PR TITLE
Linked Parameters with Parameter Names with a . don't save properly

### DIFF
--- a/Code/XTMF/Project.cs
+++ b/Code/XTMF/Project.cs
@@ -1603,7 +1603,7 @@ public sealed partial class Project : IProject
             var index = param.Parameters.IndexOf(reference);
             if (index >= 0)
             {
-                return current.Parameters.Parameters[index].Name;
+                return current.Parameters.Parameters[index].Name.Replace(".", "\\.");
             }
         }
 


### PR DESCRIPTION
In the current build of XTMF if a parameter has a linked parameter with a `.` it is being saved without the escape character `\`.  This PR adds the escape character.
