### PR TITLE
Add Passthrough ModeChoice Module

### DIFF
--- a/Tasha/XTMFModeChoice/PassthroughModeChoice.cs
+++ b/Tasha/XTMFModeChoice/PassthroughModeChoice.cs
@@ -1,0 +1,107 @@
+﻿/*
+    Copyright 2025 Travel Modelling Group, Department of Civil Engineering, University of Toronto
+
+    This file is part of XTMF.
+
+    XTMF is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    XTMF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
+using Tasha.Common;
+using XTMF;
+
+namespace Tasha.XTMFModeChoice;
+
+[ModuleInformation(Description = "A mode choice model that simply passes through the chosen modes without modification.")]
+public sealed class PassthroughModeChoice : ITashaModeChoice
+{
+
+    [RunParameter("Parallel Household Iteration", true, "Should we run all of the household iteration modules in parallel?")]
+    public bool ParallelHouseholdIteration;
+
+    [RunParameter("Household Iterations", 10, "The number of times that the mode choice should process a household.")]
+    public int HouseholdIterations;
+
+    [SubModelInformation(Required = false, Description = "The modules used for processing in between household iterations.")]
+    public IPostHouseholdIteration[] PostHouseholdIteration;
+
+    public void LoadOneTimeLocalData()
+    {
+
+    }
+
+    public void IterationStarted(int iteration, int totalIterations)
+    {
+        foreach (var module in PostHouseholdIteration)
+        {
+            module.IterationStarting(iteration, totalIterations);
+        }
+    }
+
+    public bool Run(ITashaHousehold household)
+    {
+        foreach (var module in PostHouseholdIteration)
+        {
+            module.HouseholdStart(household, HouseholdIterations);
+        }
+
+        for (int i = 0; i < HouseholdIterations; i++)
+        {
+            // Setup the household for the iteration
+            foreach (var person in household.Persons)
+            {
+                foreach (var tripChain in person.TripChains)
+                {
+                    foreach (var trip in tripChain.Trips)
+                    {
+                        var mode = trip.ModesChosen[i]; ;
+                        if(mode is null)
+                        {
+                            throw new Exception($"Trip {trip.TripNumber} for person {person.Id} in household {household.HouseholdId} does not have a chosen mode for iteration {i}.");
+                        }
+                        trip.Mode = mode;
+                    }
+                }
+            }
+            foreach (var module in PostHouseholdIteration)
+            {
+                module.HouseholdIterationComplete(household, i, HouseholdIterations);
+            }
+        }
+
+        foreach (var module in PostHouseholdIteration)
+        {
+            module.HouseholdComplete(household, true);
+        }
+        return true;
+    }
+
+    public void IterationFinished(int iteration, int totalIterations)
+    {
+        foreach (var module in PostHouseholdIteration)
+        {
+            module.IterationFinished(iteration, totalIterations);
+        }
+    }
+
+    public string Name { get; set; }
+
+    public float Progress => 0f;
+
+    public Tuple<byte, byte, byte> ProgressColour => new(50, 150, 50);
+
+    public bool RuntimeValidation(ref string error)
+    {
+        return true;
+    }
+}

--- a/Tasha/XTMFModeChoice/PassthroughModeChoice.cs
+++ b/Tasha/XTMFModeChoice/PassthroughModeChoice.cs
@@ -17,6 +17,7 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Threading.Tasks;
 using Tasha.Common;
 using XTMF;
 
@@ -42,9 +43,19 @@ public sealed class PassthroughModeChoice : ITashaModeChoice
 
     public void IterationStarted(int iteration, int totalIterations)
     {
-        foreach (var module in PostHouseholdIteration)
+        if (ParallelHouseholdIteration)
         {
-            module.IterationStarting(iteration, totalIterations);
+            Parallel.ForEach(PostHouseholdIteration, module =>
+            {
+                module.IterationStarting(iteration, totalIterations);
+            });
+        }
+        else
+        {
+            foreach (var module in PostHouseholdIteration)
+            {
+                module.IterationStarting(iteration, totalIterations);
+            }
         }
     }
 
@@ -88,9 +99,19 @@ public sealed class PassthroughModeChoice : ITashaModeChoice
 
     public void IterationFinished(int iteration, int totalIterations)
     {
-        foreach (var module in PostHouseholdIteration)
+        if (ParallelHouseholdIteration)
         {
-            module.IterationFinished(iteration, totalIterations);
+            Parallel.ForEach(PostHouseholdIteration, module =>
+            {
+                module.IterationFinished(iteration, totalIterations);
+            });
+        }
+        else
+        {
+            foreach (var module in PostHouseholdIteration)
+            {
+                module.IterationFinished(iteration, totalIterations);
+            }
         }
     }
 

--- a/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
+++ b/TorontoHouseholds/MicrosimLoader/LoadHouseholdsFromMicrosim.cs
@@ -130,13 +130,15 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
     [SubModelInformation(Required = false, Description = "A model to assign if a person is going to telecommute today.")]
     public ICalculation<ITashaPerson, bool> TelecommutingModel;
 
+    private Dictionary<string, ITashaMode> _modeMap = [];
+
     private IEnumerator<ITashaHousehold> LoadMicrosim()
     {
         var zoneSystem = SetupZoneSystem();
         HashSet<MicrosimHousehold> householdRecords = null;
         Dictionary<int, List<MicrosimPerson>> personsRecords = null;
         Dictionary<(int householdID, int personID), List<MicrosimTrip>> tripRecords = null;
-        Dictionary<(int householdID, int personID, int tripID), MicrosimTripMode> modeRecords = null;
+        Dictionary<(int householdID, int personID, int tripID), List<MicrosimTripMode>> modeRecords = null;
         // Load the microsim in parallel
         Parallel.Invoke(
         () => householdRecords = MicrosimHousehold.LoadHouseholds(this, HouseholdFile),
@@ -161,7 +163,12 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
         () => DriverLicenseModel?.Load(),
         () => TelecommutingModel?.Load()
         );
-
+        // Create the mode map
+        _modeMap.Clear();
+        foreach (var mode in Root.AllModes)
+        {
+            _modeMap[mode.ModeName] = mode;
+        }
         // Load in the households, in order, and send them off for processing
         foreach (var household in householdRecords.OrderBy(h => h.HouseholdID))
         {
@@ -239,14 +246,28 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
     [RunParameter("Mode Attribute", "", "An optional attribute name to give to the first observed mode.")]
     public string ModeAttribute;
 
-    private ITrip ConstructTrip(MicrosimTrip trip, TripChain tc, SparseArray<IZone> zoneSystem, MicrosimTripMode modeData)
+    private ITrip ConstructTrip(MicrosimTrip trip, TripChain tc, SparseArray<IZone> zoneSystem, List<MicrosimTripMode> modeData)
     {
         IZone origin = GetZone(zoneSystem, trip.OriginZone, "origin");
         IZone destination = GetZone(zoneSystem, trip.DestinationZone, "destination");
         Activity purpose = GetTripPurpose(trip.DestinationPurpose);
         if (IsHouseholdActivityPurpose(trip.DestinationPurpose))
         {
-            Time startTime = Time.FromMinutes(modeData.DepartureTime);
+            float average = 0f;
+            int totalWeight = 0;
+            int maxWeightIndex = 0;
+            for(int i = 0; i < modeData.Count; i++)
+            {
+                var mode = modeData[i];
+                average += mode.DepartureTime * mode.Weight;
+                totalWeight += mode.Weight;
+                if(mode.Weight > modeData[maxWeightIndex].Weight)
+                {
+                    maxWeightIndex = i;
+                }
+            }
+            average /= totalWeight;
+            Time startTime = Time.FromMinutes(average);
             var ret = HouseholdPurposeTrip.GetTrip(HouseholdIterations);
             ret.OriginalZone = origin;
             ret.DestinationZone = destination;
@@ -256,13 +277,36 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             ret.TripNumber = trip.TripID;
             if (!string.IsNullOrWhiteSpace(ModeAttribute))
             {
-                ret.Attach(ModeAttribute, modeData.Mode);
+                ret.Attach(ModeAttribute, modeData[maxWeightIndex].Mode);
             }
+            int pos = 0;
+            for (int i = 0; i < modeData.Count; i++)
+            {
+                for(int j = 0; j < modeData[i].Weight; j++)
+                {
+                    ret.ModesChosen[pos++] = _modeMap[modeData[i].Mode];
+                }
+            }
+            ret.Mode = _modeMap[modeData[maxWeightIndex].Mode];
             return ret;
         }
         else
         {
-            Time startTime = Time.FromMinutes(modeData.ArrivalTime);
+            float average = 0f;
+            int totalWeight = 0;
+            int maxWeightIndex = 0;
+            for (int i = 0; i < modeData.Count; i++)
+            {
+                var mode = modeData[i];
+                average += mode.ArrivalTime * mode.Weight;
+                totalWeight += mode.Weight;
+                if (mode.Weight > modeData[maxWeightIndex].Weight)
+                {
+                    maxWeightIndex = i;
+                }
+            }
+            average /= totalWeight;
+            Time startTime = Time.FromMinutes(average);
             var ret = ActivityPurposeTrip.GetTrip(HouseholdIterations);
             ret.OriginalZone = origin;
             ret.DestinationZone = destination;
@@ -272,8 +316,17 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             ret.TripNumber = trip.TripID;
             if (!string.IsNullOrWhiteSpace(ModeAttribute))
             {
-                ret.Attach(ModeAttribute, modeData.Mode);
+                ret.Attach(ModeAttribute, modeData[maxWeightIndex].Mode);
             }
+            int pos = 0;
+            for (int i = 0; i < modeData.Count; i++)
+            {
+                for (int j = 0; j < modeData[i].Weight; j++)
+                {
+                    ret.ModesChosen[pos++] = _modeMap[modeData[i].Mode];
+                }
+            }
+            ret.Mode = _modeMap[modeData[maxWeightIndex].Mode];
             return ret;
         }
     }
@@ -554,6 +607,7 @@ public class LoadHouseholdsFromMicrosim : IDataLoader<ITashaHousehold>, IDisposa
             error = $"In {Name} you must specify the attribute to store the telecommuter choice to when using the telecommuting model!";
             return false;
         }
+        
         return true;
     }
 }

--- a/TorontoHouseholds/MicrosimLoader/MicrosimTripMode.cs
+++ b/TorontoHouseholds/MicrosimLoader/MicrosimTripMode.cs
@@ -21,6 +21,8 @@ using System.IO;
 using XTMF;
 using TMG.Input;
 using Datastructure;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace TMG.Tasha.MicrosimLoader;
 
@@ -46,15 +48,20 @@ internal sealed class MicrosimTripMode
     /// </summary>
     internal readonly string Mode;
     /// <summary>
-    /// The start time of the trip.
+    /// The start time of the trip in minutes from midnight.
     /// </summary>
     internal readonly float DepartureTime;
     /// <summary>
-    /// The end time of the trip.
+    /// The end time of the trip in minutes from midnight.
     /// </summary>
     internal readonly float ArrivalTime;
 
-    private MicrosimTripMode(int householdID, int personID, int tripID, string mode, float departureTime, float arrivalTime)
+    /// <summary>
+    /// The number of times that this mode choice was observed in the data.
+    /// </summary>
+    internal readonly int Weight;
+
+    private MicrosimTripMode(int householdID, int personID, int tripID, string mode, float departureTime, float arrivalTime, int weight)
     {
         HouseholdID = householdID;
         PersonID = personID;
@@ -62,6 +69,7 @@ internal sealed class MicrosimTripMode
         Mode = mode;
         DepartureTime = departureTime;
         ArrivalTime = arrivalTime;
+        Weight = weight;
     }
 
     /// <summary>
@@ -70,14 +78,14 @@ internal sealed class MicrosimTripMode
     /// <param name="callingModule">The module invoking the call</param>
     /// <param name="tripFile">The location of the trips file to load.</param>
     /// <returns>A dictionary of all of the loaded trips indexed by the combination of the household, person, trip, and mode ids.</returns>
-    internal static Dictionary<(int householdID, int personID, int tripID), MicrosimTripMode> LoadModes(IModule callingModule, FileLocation modesFile)
+    internal static Dictionary<(int householdID, int personID, int tripID), List<MicrosimTripMode>> LoadModes(IModule callingModule, FileLocation modesFile)
     {
         var fileInfo = new FileInfo(modesFile.GetFilePath());
         if (!fileInfo.Exists)
         {
             throw new XTMFRuntimeException(callingModule, $"The file \"{fileInfo.FullName}\" does not exist!");
         }
-        var ret = new Dictionary<(int householdID, int personID, int tripID), MicrosimTripMode>(10000000);
+        var ret = new Dictionary<(int householdID, int personID, int tripID), List<MicrosimTripMode>>(10000000);
         using (var reader = new CsvReader(fileInfo))
         {
             // burn the header
@@ -92,11 +100,15 @@ internal sealed class MicrosimTripMode
                     reader.Get(out string mode, 3);
                     reader.Get(out float departureTime, 4);
                     reader.Get(out float arrivalTime, 5);
-                    // We only need to get 1 of these records
-                    if (!ret.ContainsKey((householdID, personID, tripID)))
+                    reader.Get(out int weight, 6);
+
+                    // Use unsafe code to either get the record or add the default value if it doesn't exist
+                    ref var list = ref CollectionsMarshal.GetValueRefOrAddDefault(ret, (householdID, personID, tripID), out bool success);
+                    if(!success)
                     {
-                        ret[(householdID, personID, tripID)] = new MicrosimTripMode(householdID, personID, tripID, mode, departureTime, arrivalTime);
+                        list = new List<MicrosimTripMode>(4);
                     }
+                    list.Add(new(householdID, personID, tripID, mode, departureTime, arrivalTime, weight));
                 }
             }
         }


### PR DESCRIPTION
This new module allows us to be able to send a full microsim assigned set of trips, with assignments already done
through to Post-Household Iteration modules.  This is very useful for testing new modules or re-running very
specific scenarios.
