### PR TITLE
Reduce Run Differences

### DIFF
--- a/Code/TMG.Estimation/EstimationHost.cs
+++ b/Code/TMG.Estimation/EstimationHost.cs
@@ -430,27 +430,33 @@ public sealed class EstimationHost : IEstimationHost, IDisposable
                 toWrite.Append(CultureInfo.InvariantCulture, $"{currentJob.Parameters[i].Current}");
             }
         }
+        int attempts = 0;
         while ( true )
         {
             try
             {
                 if ( HoldOnToResultFile )
                 {
-                    ResultFileWriter ??= new StreamWriter( ResultFile.GetFilePath() );
-                    Write( currentJob, toWrite, ResultFileWriter );
+                    ResultFileWriter ??= new StreamWriter(ResultFile.GetFilePath(), FirstLineToWrite);
+                    Write(currentJob, toWrite, ResultFileWriter);
                 }
                 else
                 {
                     using var writer = new StreamWriter(ResultFile.GetFilePath(), true);
                     Write(currentJob, toWrite, writer);
                 }
+                break;
             }
-            catch
+            catch(IOException e)
             {
                 // let them close the file
-                System.Threading.Thread.Sleep( 10 );
+                System.Threading.Thread.Sleep(10);
+                // allow it to try for 10 seconds
+                if(attempts++ > 1000)
+                {
+                    throw new XTMFRuntimeException(this, e, $"Unable to write to result file after multiple attempts: {e.Message}");
+                }
             }
-            break;
         }
     }
 

--- a/Code/TMG.Frameworks/Data/Processing/GravityModel2D.cs
+++ b/Code/TMG.Frameworks/Data/Processing/GravityModel2D.cs
@@ -132,7 +132,7 @@ public sealed class GravityModel2D : IDataSource<SparseTwinIndex<float>>
             case BalanceToSpatial.Global:
                 var productionTotal = VectorHelper.Sum(flatProduction, 0, flatProduction.Length);
                 var attractionTotal = VectorHelper.Sum(flatAttraction, 0, flatAttraction.Length);
-                var totalAverage = productionTotal + attractionTotal / 2.0f;
+                var totalAverage = productionTotal * 0.5f + attractionTotal * 0.5f;
                 var ratio = totalAverage / attractionTotal;
                 if (float.IsNaN(ratio) || float.IsInfinity(ratio))
                 {

--- a/Code/TMG.Functions/GravityModel.cs
+++ b/Code/TMG.Functions/GravityModel.cs
@@ -121,8 +121,7 @@ public sealed class GravityModel
     private void VectorProcessFlow(float[] columnTotals, float[][] flatFlows)
     {
         Parallel.For(0, Productions.GetFlatData().Length, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            () => new float[columnTotals.Length],
-            (flatOrigin, state, localTotals) =>
+            (flatOrigin) =>
         {
             var flatProductions = Productions.GetFlatData();
             // check to see if there is no production, if not skip this
@@ -139,16 +138,20 @@ public sealed class GravityModel
                     // this needs to be 0f, otherwise we will be making the attractions have to be balanced higher
                     sumAf = 0f;
                 }
-                VectorHelper.Multiply3Scalar1AndColumnSum(flatFlows[flatOrigin], 0, flatFrictionRow, 0, flatAttractions, 0, flatAStar, 0, sumAf, localTotals, 0, flatFriction.Length);
+                VectorHelper.Multiply(flatFlows[flatOrigin], 0, flatFrictionRow, 0, flatAttractions, 0, flatAStar, 0, sumAf, flatFriction.Length);
             }
-            return localTotals;
-        },
-        localTotals =>
+        });
+
+        // Now that everything has been computed, sum the columns
+        Parallel.For(0, columnTotals.Length,
+            (flatDest) =>
         {
-            lock (columnTotals)
+            float sum = 0f;
+            for (int i = 0; i < flatFlows.Length; i++)
             {
-                VectorHelper.Add(columnTotals, 0, columnTotals, 0, localTotals, 0, columnTotals.Length);
+                sum += flatFlows[i][flatDest];
             }
+            columnTotals[flatDest] = sum;
         });
     }
 }

--- a/Code/TMG.Functions/VectorHelper.cs
+++ b/Code/TMG.Functions/VectorHelper.cs
@@ -17,6 +17,7 @@
     along with XTMF.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -82,68 +83,54 @@ public static partial class VectorHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float Sum(float[] array, int startIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), startIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            var acc2 = Vector512<float>.Zero;
-            var acc3 = Vector512<float>.Zero;
-            int endIndex = (startIndex + length);
-            // copy everything we can do inside of a vector
-            int i = startIndex;
-            for (; i <= (endIndex - (Vector512<float>.Count * 3)); i += (Vector512<float>.Count * 3))
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                var f = Vector512.LoadUnsafe(ref array[i]);
-                var s = Vector512.LoadUnsafe(ref array[i + Vector512<float>.Count]);
-                var t = Vector512.LoadUnsafe(ref array[i + Vector512<float>.Count * 2]);
-                acc += f;
-                acc2 += s;
-                acc3 += t;
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                acc1 += f;
             }
-            // copy the remainder
-            for (; i < endIndex; i++)
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                remainderSum += array[i];
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                acc += Vector256.Sum(f);
+                i += (nuint)Vector256<float>.Count;
             }
-            acc = acc + acc2 + acc3;
-            return remainderSum + Vector512.Sum(acc);
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            var acc2 = Vector<float>.Zero;
-            var acc3 = Vector<float>.Zero;
-            int endIndex = startIndex + length;
-            // copy everything we can do inside of a vector
-            int i = startIndex;
-            for (; i <= endIndex - (Vector<float>.Count * 3); i += (Vector<float>.Count * 3))
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                var f = new Vector<float>(array, i);
-                var s = new Vector<float>(array, i + Vector<float>.Count);
-                var t = new Vector<float>(array, i + Vector<float>.Count * 2);
-                acc += f;
-                acc2 += s;
-                acc3 += t;
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);                
+                acc1 += f;
+                acc2 += f2;
             }
-            // copy the remainder
-            for (; i < endIndex; i++)
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                remainderSum += array[i];
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                acc += Vector256.Sum(f);
+                i += (nuint)Vector256<float>.Count;
             }
-            acc = acc + acc2 + acc3;
-            return remainderSum + Sum(ref acc);
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            var sum = 0.0f;
-            int end = startIndex + length;
-            for (int i = startIndex; i < end; i++)
-            {
-                sum += array[i];
-            }
-            return sum;
+            acc += Unsafe.Add(ref rf, i);
         }
+        return acc;
     }
 
     /// <summary>
@@ -158,89 +145,66 @@ public static partial class VectorHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float AbsDiffAverage(float[] first, int firstIndex, float[] second, int secondIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            var acc2 = Vector512<float>.Zero;
-            int i = firstIndex;
-            if ((firstIndex | secondIndex) == 0)
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                int highestForVector = length - (Vector512<float>.Count * 2);
-                for (; i <= highestForVector; i += Vector512<float>.Count * 2)
-                {
-                    var f1 = Vector512.LoadUnsafe(ref first[i]);
-                    var s1 = Vector512.LoadUnsafe(ref second[i]);
-                    var f2 = Vector512.LoadUnsafe(ref first[i + Vector512<float>.Count]);
-                    var s2 = Vector512.LoadUnsafe(ref second[i + Vector512<float>.Count]);
-                    acc += Vector512.Abs(f1 - s1);
-                    acc2 += Vector512.Abs(f2 - s2);
-                }
-                acc += acc2;
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var result = Vector512.Abs(f - s);
+                acc1 += result;
             }
-            else
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                int highestForVector = length - Vector512<float>.Count + firstIndex;
-                int s = secondIndex;
-                for (; i <= highestForVector; i += Vector512<float>.Count)
-                {
-                    acc += Vector512.Abs(Vector512.LoadUnsafe(ref first[i]) - Vector512.LoadUnsafe(ref second[s]));
-                    s += Vector512<float>.Count;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = Vector256.Abs(f - s);
+                acc += Vector256.Sum(result);
+                i += (nuint)Vector256<float>.Count;
             }
-            // copy the remainder
-            for (; i < length; i++)
-            {
-                remainderSum += Math.Abs(first[i + firstIndex] - second[i + secondIndex]);
-            }
-            return (remainderSum + Vector512.Sum(acc)) / length;
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            var acc2 = Vector<float>.Zero;
-            int i = firstIndex;
-            if ((firstIndex | secondIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                int highestForVector = length - (Vector<float>.Count * 2);
-                for (; i <= highestForVector; i += Vector<float>.Count * 2)
-                {
-                    var f1 = new Vector<float>(first, i);
-                    var s1 = new Vector<float>(second, i);
-                    var f2 = new Vector<float>(first, i + Vector<float>.Count);
-                    var s2 = new Vector<float>(second, i + Vector<float>.Count);
-                    acc += Vector.Abs(f1 - s1);
-                    acc2 += Vector.Abs(f2 - s2);
-                }
-                acc += acc2;
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var result1 = Vector256.Abs(f - s);
+                var result2 = Vector256.Abs(f2 - s2);
+                acc1 += result1;
+                acc2 += result2;
             }
-            else
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                int highestForVector = length - Vector<float>.Count + firstIndex;
-                int s = secondIndex;
-                for (; i <= highestForVector; i += Vector<float>.Count)
-                {
-                    acc += Vector.Abs(new Vector<float>(first, i) - new Vector<float>(second, s));
-                    s += Vector<float>.Count;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = Vector256.Abs(f - s);
+                acc += Vector256.Sum(result);
+                i += (nuint)Vector256<float>.Count;
             }
-            // copy the remainder
-            for (; i < length; i++)
-            {
-                remainderSum += Math.Abs(first[i + firstIndex] - second[i + secondIndex]);
-            }
-            return (remainderSum + Sum(ref acc)) / length;
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            float diff = 0.0f;
-            for (int i = 0; i < length; i++)
-            {
-                diff += Math.Abs(first[firstIndex + i] - second[secondIndex + i]);
-            }
-            return diff / length;
+            var result = MathF.Abs(Unsafe.Add(ref rf, i) - Unsafe.Add(ref rs, i));
+            acc += result;
         }
+        return acc / length;
     }
 
     /// <summary>
@@ -274,7 +238,7 @@ public static partial class VectorHelper
                 for (int f = 0; f <= highestForVector; f += Vector512<float>.Count)
                 {
                     vectorMax = Vector512.Max(Vector512.Abs(Vector512.LoadUnsafe(ref first[f]) - Vector512.LoadUnsafe(ref second[s])), vectorMax);
-                    s += Vector<float>.Count;
+                    s += Vector512<float>.Count;
                 }
             }
             // copy the remainder
@@ -540,99 +504,73 @@ public static partial class VectorHelper
     public static float MultiplyAndSum(float[] destination, int destIndex, float[] first, int firstIndex,
         float[] second, int secondIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rd = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), destIndex);
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            if ((destIndex | firstIndex | secondIndex) == 0)
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i]);
-                    var s = Vector512.LoadUnsafe(ref second[i]);
-                    var local = (f * s);
-                    acc += local;
-                    Vector512.StoreUnsafe(local, ref destination[i]);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += destination[i] = first[i] * second[i];
-                }
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var result = (f * s);
+                Vector512.StoreUnsafe(result, ref rd, i);
+                acc1 += result;
             }
-            else
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i + firstIndex]);
-                    var s = Vector512.LoadUnsafe(ref second[i + secondIndex]);
-                    var local = (f * s);
-                    acc += local;
-                    Vector512.StoreUnsafe(local, ref destination[i + destIndex]);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f * s;
+                Vector256.StoreUnsafe(result, ref rd, i);
+                acc += Vector256.Sum(result);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Vector512.Sum(acc);
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            if ((destIndex | firstIndex | secondIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var f = new Vector<float>(first, i);
-                    var s = new Vector<float>(second, i);
-                    var local = (f * s);
-                    acc += local;
-                    local.CopyTo(destination, i);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += destination[i] = first[i] * second[i];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var result1 = f * s;
+                var result2 = f2 * s2;
+                acc1 += result1;
+                acc2 += result2;
+                Vector256.StoreUnsafe(result1, ref rd, i);
+                Vector256.StoreUnsafe(result2, ref rd, i + (nuint)Vector256<float>.Count);
             }
-            else
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var f = new Vector<float>(first, i + firstIndex);
-                    var s = new Vector<float>(second, i + secondIndex);
-                    var local = (f * s);
-                    acc += local;
-                    local.CopyTo(destination, i + destIndex);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f * s;
+                acc += Vector256.Sum(result);
+                Vector256.StoreUnsafe(result, ref rd, i);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Sum(ref acc);
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            float remainderSum = 0.0f;
-            for (int i = 0; i < length; i++)
-            {
-                remainderSum += destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex];
-            }
-            return remainderSum;
+            var result = Unsafe.Add(ref rf, i) * Unsafe.Add(ref rs, i);
+            Unsafe.Add(ref rd, i) = result;
+            acc += result;
         }
+        return acc;
     }
 
     /// <summary>
@@ -647,98 +585,61 @@ public static partial class VectorHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float MultiplyAndSum(float[] first, int firstIndex, float[] second, int secondIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            var acc2 = Vector512<float>.Zero;
-            if ((firstIndex | secondIndex) == 0)
-            {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - (Vector512<float>.Count * 2); i += (Vector512<float>.Count * 2))
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i]);
-                    var s = Vector512.LoadUnsafe(ref second[i]);
-                    var f2 = Vector512.LoadUnsafe(ref first[i + Vector<float>.Count]);
-                    var s2 = Vector512.LoadUnsafe(ref second[i + Vector<float>.Count]);
 
-                    acc += (f * s);
-                    acc2 += (f2 * s2);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i] * second[i];
-                }
-                acc += acc2;
-            }
-            else
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    acc += (Vector512.LoadUnsafe(ref first[i + firstIndex]) * Vector512.LoadUnsafe(ref second[i + secondIndex]));
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i + firstIndex] * second[i + secondIndex];
-                }
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                acc1 += (f * s);
             }
-            return remainderSum + Vector512.Sum(acc);
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
+            {
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                acc += Vector256.Sum(f * s);
+                i += (nuint)Vector256<float>.Count;
+            }
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            var acc2 = Vector<float>.Zero;
-            if ((firstIndex | secondIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - (Vector<float>.Count * 2); i += (Vector<float>.Count * 2))
-                {
-                    var f = new Vector<float>(first, i);
-                    var s = new Vector<float>(second, i);
-                    var f2 = new Vector<float>(first, i + Vector<float>.Count);
-                    var s2 = new Vector<float>(second, i + Vector<float>.Count);
-                    acc += (f * s);
-                    acc2 += (f2 * s2);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i] * second[i];
-                }
-                acc += acc2;
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                acc1 += (f * s);
+                acc2 += (f2 * s2);
             }
-            else
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    acc += (new Vector<float>(first, i + firstIndex) * new Vector<float>(second, i + secondIndex));
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i + firstIndex] * second[i + secondIndex];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                acc += Vector256.Sum(f * s);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Sum(ref acc);
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            var remainderSum = 0.0f;
-            for (int i = 0; i < length; i++)
-            {
-                remainderSum += first[i + firstIndex] * second[i + secondIndex];
-            }
-            return remainderSum;
+            acc += Unsafe.Add(ref rf, i) * Unsafe.Add(ref rs, i);
         }
+        return acc;
     }
 
     /// <summary>
@@ -749,23 +650,13 @@ public static partial class VectorHelper
     /// <returns>The sum of the products of the two arrays.</returns>
     public static float MultiplyAndSum(float[][] first, float[][] second)
     {
-        object lockObject = new();
-        float ret = 0.0f;
+        float[] rowResult = new float [first.Length];
         Parallel.For(0, first.Length,
-            () => 0f,
-            (i, _, local) =>
+            (i) =>
             {
-                local += MultiplyAndSum(first[i], 0, second[i], 0, first.Length);
-                return local;
-            },
-            (local) =>
-            {
-                lock (lockObject)
-                {
-                    ret += local;
-                }
+                rowResult[i] = MultiplyAndSum(first[i], 0, second[i], 0, first.Length);
             });
-        return ret;
+        return Sum(rowResult, 0, rowResult.Length);
     }
 
     /// <summary>
@@ -783,104 +674,66 @@ public static partial class VectorHelper
     public static float Multiply3AndSum(float[] first, int firstIndex, float[] second, int secondIndex,
         float[] third, int thirdIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        ref var rt = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(third), thirdIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            var acc2 = Vector512<float>.Zero;
-            if ((firstIndex | secondIndex | thirdIndex) == 0)
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                int i = 0;
-                // copy everything we can do inside of a vector
-                for (; i <= length - (Vector512<float>.Count * 2); i += (Vector512<float>.Count * 2))
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i]);
-                    var s = Vector512.LoadUnsafe(ref second[i]);
-                    var t = Vector512.LoadUnsafe(ref third[i]);
-                    var f2 = Vector512.LoadUnsafe(ref first[i + Vector512<float>.Count]);
-                    var s2 = Vector512.LoadUnsafe(ref second[i + Vector512<float>.Count]);
-                    var t2 = Vector512.LoadUnsafe(ref third[i + Vector512<float>.Count]);
-                    acc += (f * s * t);
-                    acc2 += (f2 * s2 * t2);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i] * second[i] * third[i];
-                }
-                acc += acc2;
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var t = Vector512.LoadUnsafe(ref rt, i);
+                acc1 += (f * s * t);
             }
-            else
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i + firstIndex]);
-                    var s = Vector512.LoadUnsafe(ref second[i + secondIndex]);
-                    var t = Vector512.LoadUnsafe(ref third[i + thirdIndex]);
-                    var local = (f * s * t);
-                    acc += local;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector512<float>.Count); i < length; i++)
-                {
-                    remainderSum += first[i + firstIndex] * second[i + secondIndex] * third[i + thirdIndex];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var t = Vector256.LoadUnsafe(ref rt, i);
+                acc += Vector256.Sum(f * s * t);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Vector512.Sum(acc);
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            var acc2 = Vector<float>.Zero;
-            if ((firstIndex | secondIndex | thirdIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                int i = 0;
-                // copy everything we can do inside of a vector
-                for (; i <= length - (Vector<float>.Count * 2); i += (Vector<float>.Count * 2))
-                {
-                    var f = new Vector<float>(first, i);
-                    var s = new Vector<float>(second, i);
-                    var t = new Vector<float>(third, i);
-                    var f2 = new Vector<float>(first, i + Vector<float>.Count);
-                    var s2 = new Vector<float>(second, i + Vector<float>.Count);
-                    var t2 = new Vector<float>(third, i + Vector<float>.Count);
-                    acc += (f * s * t);
-                    acc2 += (f2 * s2 * t2);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    remainderSum += first[i] * second[i] * third[i];
-                }
-                acc += acc2;
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var t = Vector256.LoadUnsafe(ref rt, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var t2 = Vector256.LoadUnsafe(ref rt, i + (nuint)Vector256<float>.Count);
+                acc1 += (f * s * t);
+                acc2 += (f2 * s2 * t2);
             }
-            else
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var local = (new Vector<float>(first, i + firstIndex) * new Vector<float>(second, i + secondIndex) * new Vector<float>(third, i + thirdIndex));
-                    acc += local;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    remainderSum += first[i + firstIndex] * second[i + secondIndex] * third[i + thirdIndex];
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var t = Vector256.LoadUnsafe(ref rt, i);
+                acc += Vector256.Sum(f * s * t);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Sum(ref acc);
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            var remainderSum = 0.0f;
-            for (int i = 0; i < length; i++)
-            {
-                remainderSum += first[i + firstIndex] * second[i + secondIndex] * third[i + thirdIndex];
-            }
-            return remainderSum;
+            acc += Unsafe.Add(ref rf, i) * Unsafe.Add(ref rs, i) * Unsafe.Add(ref rt, i);
         }
+        return acc;
     }
 
     /// <summary>
@@ -901,82 +754,73 @@ public static partial class VectorHelper
     public static void Multiply2Scalar1AndColumnSum(float[] destination, int destIndex, float[] first, int firstIndex,
         float[] second, int secondIndex, float scalar, float[] columnSum, int columnIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rd = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), destIndex);
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        ref var rc = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(columnSum), columnIndex);
+        nuint i = 0;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var scalarV = Vector512.Create(scalar);
-            if ((destIndex | firstIndex | secondIndex | columnIndex) == 0)
+            Vector512<float> t = Vector512.Create(scalar);
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var local = Vector512.LoadUnsafe(ref first[i]) * Vector512.LoadUnsafe(ref second[i]) * scalarV;
-                    Vector512.StoreUnsafe((Vector512.LoadUnsafe(ref columnSum[i]) + local), ref columnSum[i]);
-                    Vector512.StoreUnsafe(local, ref destination[i]);
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector512<float>.Count); i < length; i++)
-                {
-                    columnSum[i] += (destination[i] = first[i] * second[i] * scalar);
-                }
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var c = Vector512.LoadUnsafe(ref rc, i);
+                Vector512<float> result = (f * s * t);
+                Vector512.StoreUnsafe(result, ref rd, i);
+                Vector512.StoreUnsafe(c + result, ref rc, i);
             }
-            else
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var local = Vector512.LoadUnsafe(ref first[i + firstIndex]) * Vector512.LoadUnsafe(ref second[i + secondIndex]) * scalarV;
-                    Vector512.StoreUnsafe(Vector512.LoadUnsafe(ref columnSum[i + columnIndex]) + local, ref columnSum[i + columnIndex]);
-                    Vector512.StoreUnsafe(local, ref destination[i + destIndex]);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    columnSum[i + columnIndex] += (destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex] * scalar);
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var c = Vector256.LoadUnsafe(ref rc, i);
+                var result = f * s * t.GetLower();
+                Vector256.StoreUnsafe(result, ref rd, i);
+                Vector256.StoreUnsafe(c + result, ref rc, i);
+                i += (nuint)Vector256<float>.Count;
             }
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            Vector<float> scalarV = new(scalar);
-            if ((destIndex | firstIndex | secondIndex | columnIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> t = Vector256.Create(scalar);
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var local = new Vector<float>(first, i) * new Vector<float>(second, i) * scalarV;
-                    (new Vector<float>(columnSum, i) + local).CopyTo(columnSum, i);
-                    local.CopyTo(destination, i);
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    columnSum[i] += (destination[i] = first[i] * second[i] * scalar);
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var c = Vector256.LoadUnsafe(ref rc, i);
+                var c2 = Vector256.LoadUnsafe(ref rc, i + (nuint)Vector256<float>.Count);
+                var result1 = f * s * t;
+                var result2 = f2 * s2 * t;
+                Vector256.StoreUnsafe(result1, ref rd, i);
+                Vector256.StoreUnsafe(result2, ref rd, i + (nuint)Vector256<float>.Count);
+                Vector256.StoreUnsafe(c + result1, ref rc, i);
+                Vector256.StoreUnsafe(c2 + result2, ref rc, i + (nuint)Vector256<float>.Count);
             }
-            else
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                int i = 0;
-                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var local = new Vector<float>(first, i + firstIndex) * new Vector<float>(second, i + secondIndex) * scalarV;
-                    (new Vector<float>(columnSum, i + columnIndex) + local).CopyTo(columnSum, i + columnIndex);
-                    local.CopyTo(destination, i + destIndex);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    columnSum[i + columnIndex] += (destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex] * scalar);
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var c = Vector256.LoadUnsafe(ref rc, i);
+                var result = f * s * t;
+                Vector256.StoreUnsafe(result, ref rd, i);
+                Vector256.StoreUnsafe(c + result, ref rc, i);
+                i += (nuint)Vector256<float>.Count;
             }
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            for (int i = 0; i < length; i++)
-            {
-                columnSum[i + columnIndex] += (destination[i + destIndex] = first[i + firstIndex] * second[i + secondIndex] * scalar);
-            }
+            var result = Unsafe.Add(ref rf, i) * Unsafe.Add(ref rs, i) * scalar;
+            Unsafe.Add(ref rd, i) = result;
+            Unsafe.Add(ref rc, i) += result;
         }
     }
 

--- a/Code/TMG.Functions/VectorHelper.cs
+++ b/Code/TMG.Functions/VectorHelper.cs
@@ -1013,80 +1013,62 @@ public static partial class VectorHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Average(float[] destination, int destIndex, float[] first, int firstIndex, float[] second, int secondIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rd = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(destination), destIndex);
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        nuint i = 0;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
             Vector512<float> half = Vector512.Create(0.5f);
-            if ((destIndex | firstIndex | secondIndex) == 0)
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                int i = 0;
-                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i]);
-                    var s = Vector512.LoadUnsafe(ref second[i]);
-                    Vector512.StoreUnsafe((f + s) * half,
-                        ref destination[i]);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    destination[i] = (first[i] + second[i]) * 0.5f;
-                }
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                Vector512<float> result = (f * half) + (s * half);
+                Vector512.StoreUnsafe(result, ref rd, i);
             }
-            else
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                for (int i = 0; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var f = Vector512.LoadUnsafe(ref first[i + firstIndex]);
-                    var s = Vector512.LoadUnsafe(ref second[i + secondIndex]);
-                    Vector512.StoreUnsafe((f + s) * half,
-                        ref destination[i + destIndex]);
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    destination[i + destIndex] = (first[i + firstIndex] + second[i + secondIndex]) * 0.5f;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var half256 = Vector256.Create(0.5f);
+                var result = (f * half256) + (s * half256);
+                Vector256.StoreUnsafe(result, ref rd, i);
+                i += (nuint)Vector256<float>.Count;
             }
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            Vector<float> half = new(0.5f);
-            if ((destIndex | firstIndex | secondIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> half = Vector256.Create(0.5f);
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                int i = 0;
-                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var f = new Vector<float>(first, i);
-                    var s = new Vector<float>(second, i);
-                    ((f + s) * half).CopyTo(destination, i);
-                }
-                // copy the remainder
-                for (; i < length; i++)
-                {
-                    destination[i] = (first[i] + second[i]) * 0.5f;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var result1 = (f * half) + (s + half);
+                var result2 = (f2 * half) + (s2 * half);
+                Vector256.StoreUnsafe(result1, ref rd, i);
+                Vector256.StoreUnsafe(result2, ref rd, i + (nuint)Vector256<float>.Count);
             }
-            else
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                for (int i = 0; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var f = new Vector<float>(first, i + firstIndex);
-                    var s = new Vector<float>(second, i + secondIndex);
-                    ((f + s) * half).CopyTo(destination, i + destIndex);
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    destination[i + destIndex] = (first[i + firstIndex] + second[i + secondIndex]) * 0.5f;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = (f * half) + (s * half);
+                Vector256.StoreUnsafe(result, ref rd, i);
+                i += (nuint)Vector256<float>.Count;
             }
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            for (int i = 0; i < length; i++)
-            {
-                destination[i + destIndex] = (first[i + firstIndex] + second[i + secondIndex]) * 0.5f;
-            }
+            var result = (Unsafe.Add(ref rf, i) * 0.5f) + (Unsafe.Add(ref rs, i) * 0.5f);
+            Unsafe.Add(ref rd, i) = result;
         }
     }
 

--- a/Code/TMG.Functions/VectorHelper.cs
+++ b/Code/TMG.Functions/VectorHelper.cs
@@ -312,89 +312,66 @@ public static partial class VectorHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float SquareDiff(float[] first, int firstIndex, float[] second, int secondIndex, int length)
     {
-        if (Vector512.IsHardwareAccelerated)
+        ref var rf = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(first), firstIndex);
+        ref var rs = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(second), secondIndex);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector512<float>.Zero;
-            if ((firstIndex | secondIndex) == 0)
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var diff = Vector512.LoadUnsafe(ref first[i]) - Vector512.LoadUnsafe(ref second[i]);
-                    acc += diff * diff;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    var diff = first[i] - second[i];
-                    remainderSum += diff * diff;
-                }
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var result = f - s;
+                acc1 += result * result;
             }
-            else
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
-                {
-                    var diff = Vector512.LoadUnsafe(ref first[i + firstIndex]) - Vector512.LoadUnsafe(ref second[i + secondIndex]);
-                    acc += diff * diff;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector512<float>.Count); i < length; i++)
-                {
-                    var diff = first[i + firstIndex] - second[i + secondIndex];
-                    remainderSum += diff * diff;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f * s;
+                acc += Vector256.Sum(result * result);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Vector512.Sum(acc);
         }
-        else if (Vector.IsHardwareAccelerated)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            var remainderSum = 0.0f;
-            var acc = Vector<float>.Zero;
-            if ((firstIndex | secondIndex) == 0)
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var diff = new Vector<float>(first, i) - new Vector<float>(second, i);
-                    acc += diff * diff;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    var diff = first[i] - second[i];
-                    remainderSum += diff * diff;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var result1 = f - s;
+                var result2 = f2 - s2;
+                acc1 += result1 * result1;
+                acc2 += result2 * result2;
             }
-            else
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
             {
-                // copy everything we can do inside of a vector
-                for (int i = 0; i <= length - Vector<float>.Count; i += Vector<float>.Count)
-                {
-                    var diff = new Vector<float>(first, i + firstIndex) - new Vector<float>(second, i + secondIndex);
-                    acc += diff * diff;
-                }
-                // copy the remainder
-                for (int i = length - (length % Vector<float>.Count); i < length; i++)
-                {
-                    var diff = first[i + firstIndex] - second[i + secondIndex];
-                    remainderSum += diff * diff;
-                }
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f - s;
+                acc += Vector256.Sum(result * result);
+                i += (nuint)Vector256<float>.Count;
             }
-            return remainderSum + Sum(ref acc);
         }
-        else
+        // Add the remainder
+        for (; i < (nuint)length; i++)
         {
-            var diff2 = 0.0f;
-            for (int i = 0; i < length; i++)
-            {
-                // no abs needed since we are going to square
-                var diff = first[firstIndex + i] - second[secondIndex + i];
-                diff2 += diff * diff;
-            }
-            return diff2;
+            var result = MathF.Abs(Unsafe.Add(ref rf, i) - Unsafe.Add(ref rs, i));
+            acc += result * result;
         }
+        return acc;
     }
 
     /// <summary>

--- a/Code/TMG.Functions/VectorHelper/Multiply.cs
+++ b/Code/TMG.Functions/VectorHelper/Multiply.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 using System.Threading.Tasks;
@@ -607,24 +608,156 @@ public static partial class VectorHelper
         }       
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <param name="destIndex"></param>
+    /// <param name="first"></param>
+    /// <param name="firstIndex"></param>
+    /// <param name="second"></param>
+    /// <param name="secondIndex"></param>
+    /// <param name="third"></param>
+    /// <param name="thirdIndex"></param>
+    /// <param name="fourth"></param>
+    /// <param name="fourthIndex"></param>
+    /// <param name="length"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Multiply(float[] destination, int destIndex, float[] first, int firstIndex, float[] second, int secondIndex,
+        float[] third, int thirdIndex, float fourth, int length)
+    {
+        int i = 0;
+        if ((destIndex | firstIndex | secondIndex | thirdIndex) == 0)
+        {
+            if (Vector512.IsHardwareAccelerated)
+            {
+                var f4 = Vector512.Create(fourth);
+                // copy everything we can do inside of a vector
+                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
+                {
+                    var f = Vector512.LoadUnsafe(ref first[i]);
+                    var s = Vector512.LoadUnsafe(ref second[i]);
+                    var t = Vector512.LoadUnsafe(ref third[i]);
+                    Vector512.StoreUnsafe((f * s) * (t * f4), ref destination[i]);
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
+            {
+                var f4 = Vector.Create(fourth);
+                // copy everything we can do inside of a vector
+                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
+                {
+                    var f = new Vector<float>(first, i);
+                    var s = new Vector<float>(second, i);
+                    var t = new Vector<float>(third, i);
+                    ((f * s) * (t * f4)).CopyTo(destination, i);
+                }
+            }
+            // copy the remainder
+            for (; i < length; i++)
+            {
+                destination[i] = (first[i] * second[i]) * (third[i] * fourth);
+            }
+        }
+        else
+        {
+            if (Vector512.IsHardwareAccelerated)
+            {
+                var f4 = Vector512.Create(fourth);
+                // copy everything we can do inside of a vector
+                for (; i <= length - Vector512<float>.Count; i += Vector512<float>.Count)
+                {
+                    var f = Vector512.LoadUnsafe(ref first[i + firstIndex]);
+                    var s = Vector512.LoadUnsafe(ref second[i + secondIndex]);
+                    var t = Vector512.LoadUnsafe(ref third[i + thirdIndex]);
+                    Vector512.StoreUnsafe((f * s) * (t * f4), ref destination[i + destIndex]);
+                }
+            }
+            else if (Vector.IsHardwareAccelerated)
+            {
+                var f4 = Vector.Create(fourth);
+                // copy everything we can do inside of a vector
+                for (; i <= length - Vector<float>.Count; i += Vector<float>.Count)
+                {
+                    var f = new Vector<float>(first, i + firstIndex);
+                    var s = new Vector<float>(second, i + secondIndex);
+                    var t = new Vector<float>(third, i + thirdIndex);
+                    ((f * s) * (t * f4)).CopyTo(destination, i + destIndex);
+                }
+            }
+            // copy the remainder
+            for (; i < length; i++)
+            {
+                destination[i + destIndex] = (first[i + firstIndex] * second[i + secondIndex]) * (third[i + thirdIndex] * fourth);
+            }
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static float MultiplyAndSumNoStore(Span<float> first, Span<float> second)
     {
-        // Make sure our data is of the right size
-        if (first.Length != second.Length) ThrowVectorsMustBeSameSize();
-        var remainder = first.Length % Vector<float>.Count;
-        var accV = Vector<float>.Zero;
-        var acc = 0.0f;
-        var firstV = first[..^remainder].ReinterpretSpan<float, Vector<float>>();
-        var secondV = second[..^remainder].ReinterpretSpan<float, Vector<float>>();
-        for (int i = 0; i < firstV.Length; i++)
+        if(first.Length != second.Length) ThrowVectorsMustBeSameSize();
+
+        var length = first.Length;
+        ref var rf = ref MemoryMarshal.GetReference(first);
+        ref var rs = ref MemoryMarshal.GetReference(second);
+        nuint i = 0;
+        float acc = 0.0f;
+        // 16 floats per Vector512, we hard code this here just in case Vector512 is not supported
+        var end = (nuint)(length - 16);
+        if (Vector512.IsHardwareAccelerated && length >= 16)
         {
-            accV += firstV[i] * secondV[i];
+            Vector512<float> acc1 = Vector512<float>.Zero;
+            for (; i <= end; i += (nuint)Vector512<float>.Count)
+            {
+                var f = Vector512.LoadUnsafe(ref rf, i);
+                var s = Vector512.LoadUnsafe(ref rs, i);
+                var result = (f * s);
+                acc1 += result;
+            }
+            acc += Vector512.Sum(acc1);
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
+            {
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f * s;
+                acc += Vector256.Sum(result);
+                i += (nuint)Vector256<float>.Count;
+            }
         }
-        for (int i = first.Length - remainder; i < first.Length; i++)
+        else if (Vector256.IsHardwareAccelerated && length >= 16)
         {
-            acc += first[i] * second[i];
+            // Vector256 needs to be doubled to match the same results as Vector512
+            Vector256<float> acc1 = Vector256<float>.Zero;
+            Vector256<float> acc2 = Vector256<float>.Zero;
+            for (; i <= end; i += (nuint)(Vector256<float>.Count * 2))
+            {
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var f2 = Vector256.LoadUnsafe(ref rf, i + (nuint)Vector256<float>.Count);
+                var s2 = Vector256.LoadUnsafe(ref rs, i + (nuint)Vector256<float>.Count);
+                var result1 = f * s;
+                var result2 = f2 * s2;
+                acc1 += result1;
+                acc2 += result2;
+            }
+            acc += Vector256.Sum(acc1 + acc2);
+            // If there is one more Vector256 left, add it in
+            if ((nuint)length - i >= (nuint)Vector256<float>.Count)
+            {
+                var f = Vector256.LoadUnsafe(ref rf, i);
+                var s = Vector256.LoadUnsafe(ref rs, i);
+                var result = f * s;
+                acc += Vector256.Sum(result);
+                i += (nuint)Vector256<float>.Count;
+            }
         }
-        return Vector.Sum(accV) + acc;
+        // Add the remainder
+        for (; i < (nuint)length; i++)
+        {
+            var result = Unsafe.Add(ref rf, i) * Unsafe.Add(ref rs, i);
+            acc += result;
+        }
+        return acc;
     }
 }

--- a/Tasha/Estimation/IntegrateIntoEstimationFramework.cs
+++ b/Tasha/Estimation/IntegrateIntoEstimationFramework.cs
@@ -102,11 +102,11 @@ public class IntegrateIntoEstimationFramework : IPostHousehold
                     Array.Clear(trip.ModesChosen, 0, trip.ModesChosen.Length);
                     fitness += value;
                 }
-                // chain.Release();
+                chain.Release();
             }
-            // p.Release();
+            p.Release();
         }
-        // household.Release();
+        household.Release();
         return fitness;
     }
 

--- a/Tasha/StationAccess/ComputeStationCapacityFactor.cs
+++ b/Tasha/StationAccess/ComputeStationCapacityFactor.cs
@@ -98,57 +98,50 @@ public class ComputeStationCapacityFactor : IPostIteration
             }, DemandMatrix);
         }
 
-        private void ProcessData(float[] autoTripMatrix, int iteration, float[] currentStationCount)
+        private void ProcessData(float[] autoTripMatrix, int iteration, float[] currentStationCounts)
         {
             var zones = Root.ZoneSystem.ZoneArray.GetFlatData();
             int[] zoneIndexForStation = Parent.AccessZoneIndexes;
-            // Make a local copy of the station counts for this time period to reduce the number of adds going forward.
-            float[] tempStationCounts = new float[zoneIndexForStation.Length];
             // a fast way of tallying the station counts
-            Parallel.For(0, zones.Length,
-                () => { return new float[zoneIndexForStation.Length]; },
-                (i, state, threadLocalStationAccessCounts) =>
+            Parallel.For(0, zoneIndexForStation.Length,
+                (j) =>
                 {
-                    var iOffset = i * zones.Length;
+                    var jOffset = zoneIndexForStation[j];
                     var invPHF = 1.0f / PeakHourFactor;
-                    for (int j = 0; j < zoneIndexForStation.Length; j++)
+                    var acc = 0.0f;
+                    for (int i = 0; i < zones.Length; i++)
                     {
-                        var inbound = autoTripMatrix[iOffset + zoneIndexForStation[j]];
-                        var outbound = Parent.CascadingDemand ? autoTripMatrix[zoneIndexForStation[j] * zones.Length + i] : 0.0f;
-                        threadLocalStationAccessCounts[j] += invPHF * (inbound - outbound);
+                        var inbound = autoTripMatrix[i * zones.Length + jOffset];
+                        var outbound = Parent.CascadingDemand ? autoTripMatrix[jOffset * zones.Length + i] : 0.0f;
+                        acc += invPHF * (inbound - outbound);
                     }
-                    return threadLocalStationAccessCounts;
-                },
-                threadLocalAccessStationCounts =>
-                {
-                    lock (tempStationCounts)
-                    {
-                        VectorHelper.Add(tempStationCounts, threadLocalAccessStationCounts, tempStationCounts.Length);
-                    }
+                    currentStationCounts[j] += acc;
                 });
-            // Update the station time period counts to include this time period's
-            VectorHelper.Add(currentStationCount, tempStationCounts, currentStationCount.Length);
             var capacity = Parent.Capacity.GetFlatData();
             if (CapacityFactors == null || iteration == 0)
             {
-                CapacityFactors = new float[currentStationCount.Length];
+                CapacityFactors = new float[currentStationCounts.Length];
+                for (int i = 0; i < CapacityFactors.Length; i++)
+                {
+                    CapacityFactors[i] = 0.0f;
+                }
             }
             var previousFraction = iteration > 0 ? 1.0f / (iteration + 1.0f) : 0.0f;
             var currentFraction = iteration > 0 ? iteration / (1.0f + iteration) : 1.0f;
             using var writer = new StreamWriter(CapacityFactorOutput);
             writer.WriteLine("Zone,Factor,Demand,Capacity");
             Span<char> buffer = stackalloc char[32];
-            for (int i = 0; i < currentStationCount.Length; i++)
+            for (int i = 0; i < currentStationCounts.Length; i++)
             {
                 float stationCapacity = capacity[zoneIndexForStation[i]];
-                if (ComputeStationCapacityFactor(previousFraction, currentFraction, currentStationCount[i], stationCapacity, CapacityFactors[i], out float capacityFactor))
+                if (ComputeStationCapacityFactor(previousFraction, currentFraction, currentStationCounts[i], stationCapacity, CapacityFactors[i], out float capacityFactor))
                 {
                     CapacityFactors[i] = capacityFactor;
                     TMG.Functions.Utilities.Write(writer, zones[zoneIndexForStation[i]].ZoneNumber, buffer);
                     writer.Write(',');
                     TMG.Functions.Utilities.Write(writer, capacityFactor, buffer);
                     writer.Write(',');
-                    TMG.Functions.Utilities.Write(writer, currentStationCount[i], buffer);
+                    TMG.Functions.Utilities.Write(writer, currentStationCounts[i], buffer);
                     writer.Write(',');
                     TMG.Functions.Utilities.WriteLine(writer, CapacityMultiplier * stationCapacity, buffer);
                 }
@@ -243,14 +236,14 @@ public class ComputeStationCapacityFactor : IPostIteration
             LoadStationCapacity();
             LoadAccessZones();
         }
-        // The number of vehicles parked at the station after each time period.
-        float[] currentStationCount = new float[AccessZoneIndexes.Length];
+        // Process each time period
+        float[] autoCount = new float[AccessZoneIndexes.Length];
         foreach (var period in TimePeriods)
         {
-            period.Execute(iterationNumber, currentStationCount);
+            period.Execute(iterationNumber, autoCount);
             if (!CascadingDemand)
             {
-                Array.Clear(currentStationCount, 0, currentStationCount.Length);
+                Array.Clear(autoCount, 0, autoCount.Length);
             }
         }
     }


### PR DESCRIPTION
In the current implementation of TASHA there are a number of places where the order of adding floating point numbers changes depending on which thread finishes the calculation first.  This can lead to small rounding differences in the final answers.  Additionally there are some places where different computers, with different instruction sets, would produce slightly different results because the size of the SIMD registers used are different.  Changes have been made to double the number of accumulators so that both instruction sets should have the same number of accumulators.



