### PR TITLE
Stop RandomSeed from being zero

### DIFF
--- a/Code/GTAModel/PORPOW.cs
+++ b/Code/GTAModel/PORPOW.cs
@@ -108,6 +108,11 @@ public class PORPOW : ISelfContainedModule
                 return false;
             }
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/GTAModel/PopulationSynthesis.cs
+++ b/Code/GTAModel/PopulationSynthesis.cs
@@ -93,6 +93,11 @@ public class PopulationSynthesis : ITravelDemandModel
 
     public bool RuntimeValidation(ref string error)
     {
+        if(RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/NetworkEstimation/NetworkAI.cs
+++ b/Code/NetworkEstimation/NetworkAI.cs
@@ -218,6 +218,11 @@ public class NetworkAi : INetworkEstimationAI
             error = "The momentum residule can not be less than 0!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/NetworkEstimation/NetworkGravityDescent.cs
+++ b/Code/NetworkEstimation/NetworkGravityDescent.cs
@@ -155,6 +155,11 @@ public class NetworkGravityDescent : INetworkEstimationAI
 
     public bool RuntimeValidation(ref string error)
     {
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/TMG.Estimation/AI/GeneticAI.cs
+++ b/Code/TMG.Estimation/AI/GeneticAI.cs
@@ -314,6 +314,11 @@ public class GeneticAI : IEstimationAI
             error = "You can not reseed more than the size of the population!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         Random = new Random( RandomSeed );
         return true;
     }

--- a/Code/TMG.Estimation/AI/GradientAI.cs
+++ b/Code/TMG.Estimation/AI/GradientAI.cs
@@ -242,6 +242,11 @@ The total points explored will be the number of kernels*(#parameters * 2 + 1)." 
 
     public bool RuntimeValidation(ref string error)
     {
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         Random = new Random( RandomSeed );
         return true;
     }

--- a/Code/TMG.Estimation/AI/GravityOptimization.cs
+++ b/Code/TMG.Estimation/AI/GravityOptimization.cs
@@ -620,6 +620,11 @@ public class GravityOptimization : IEstimationAI
             error = "In '" + Name + "' there must be more particles than stars!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/TMG.Estimation/AI/HybridPSOGD.cs
+++ b/Code/TMG.Estimation/AI/HybridPSOGD.cs
@@ -641,6 +641,11 @@ public class HybridPSOGD : IEstimationAI
             error = "In '" + Name + "' the swarm size must be greater than 1!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 }

--- a/Code/TMG.Estimation/AI/ParticleSwarmOptimization.cs
+++ b/Code/TMG.Estimation/AI/ParticleSwarmOptimization.cs
@@ -393,6 +393,11 @@ public class ParticleSwarmOptimization : IEstimationAI
             error = "In '" + Name + "' the swarm size must be greater than 1!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 }

--- a/Code/TMG.Frameworks/Data/Processing/IntegerizeMatrix.cs
+++ b/Code/TMG.Frameworks/Data/Processing/IntegerizeMatrix.cs
@@ -199,6 +199,11 @@ public sealed class IntegerizeMatrix : IDataSource<SparseTwinIndex<float>>
 
     public bool RuntimeValidation(ref string error)
     {
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/TMG.Frameworks/Data/Synthesis/Gibbs/Aggregation.cs
+++ b/Code/TMG.Frameworks/Data/Synthesis/Gibbs/Aggregation.cs
@@ -219,6 +219,11 @@ public class Aggregation : IModule
 
         public bool RuntimeValidation(ref string error)
         {
+            if (RandomSeed == 0)
+            {
+                error = "Random Seed cannot be 0";
+                return false;
+            }
             if ((_SecondaryPool = Root.Pools.FirstOrDefault(p => p.Name == SecondaryPool.Data)) == null)
             {
                 error = $"In '{Name}' we were unable to find a pool with the name '{SecondaryPool.Data}'.";

--- a/Code/TMG.Frameworks/Data/Synthesis/Gibbs/Pool.cs
+++ b/Code/TMG.Frameworks/Data/Synthesis/Gibbs/Pool.cs
@@ -194,6 +194,11 @@ public class Pool : IModule
             }
         }
         // ZoneSystem can still be null at the end of this
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 }

--- a/Code/TMG.Frameworks/Extensibility/ExecuteModelSystemWithRandomSeeds.cs
+++ b/Code/TMG.Frameworks/Extensibility/ExecuteModelSystemWithRandomSeeds.cs
@@ -73,6 +73,11 @@ public class ExecuteModelSystemWithRandomSeeds : IModelSystemTemplate
             error = "Unable to start at negative indexed line! Please select non-negative value for 'Row to Start From'!";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/Tasha.Validation/ODMatrixBuilder.cs
+++ b/Code/Tasha.Validation/ODMatrixBuilder.cs
@@ -198,6 +198,11 @@ public class ODMatrixBuilder : ITashaRuntime
 
     public bool RuntimeValidation(ref string error)
     {
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/Tasha.Validation/RandomTashaSeeds.cs
+++ b/Code/Tasha.Validation/RandomTashaSeeds.cs
@@ -73,6 +73,11 @@ public class RandomTashaSeeds : IModelSystemTemplate
 
     public bool RuntimeValidation(ref string error)
     {
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 

--- a/Code/Tasha.Validation/ValidateModeChoice/ModifyAutoOwnership.cs
+++ b/Code/Tasha.Validation/ValidateModeChoice/ModifyAutoOwnership.cs
@@ -83,6 +83,11 @@ public sealed class ModifyAutoOwnership : ICalculation<ITashaHousehold, int>
             error = "Expected Change must be in the range [-1,1]";
             return false;
         }
+        if (RandomSeed == 0)
+        {
+            error = "Random Seed cannot be 0";
+            return false;
+        }
         return true;
     }
 }

--- a/Code/XTMFCoreTesting/Editing/TestModelSystemEditingSession.cs
+++ b/Code/XTMFCoreTesting/Editing/TestModelSystemEditingSession.cs
@@ -297,17 +297,17 @@ public class TestModelSystemEditingSession
         var oldName = root.Name;
         const string? newName = "New Name";
         Assert.IsTrue(root.SetName(newName, ref error), "Failed to set the module's name!");
-        Assert.AreEqual(root.Name, newName, "The new name was not assigned!");
+        Assert.AreEqual(newName, root.Name, "The new name was not assigned!");
         if (!session.Undo(ref error))
         {
             Assert.Fail("We were unable to undo! " + error);
         }
-        Assert.AreEqual(root.Name, oldName, "The old name was not restored!");
+        Assert.AreEqual(oldName, root.Name, "The old name was not restored!");
         if (!session.Redo(ref error))
         {
             Assert.Fail("We were unable to redo! " + error);
         }
-        Assert.AreEqual(root.Name, newName, "The new name was not restored after redo!");
+        Assert.AreEqual(newName, root.Name, "The new name was not restored after redo!");
     }
 
     [TestMethod]


### PR DESCRIPTION
If a random seed is zero this can end up with very odd behaviour for the random number generator, and how we initialize secondary random number seeds.  This patch adds a check at runtime to make sure this does not happen.
